### PR TITLE
Mute and Video Scaling buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ This project has the following features (still WIP):
  - [x] Refactor to have a blit function which queues up transfers for screen into a task
  - [x] Scaling of GB/GBC display to support original, fit, and fill video scaling modes
  - [x] Scaling for NES display to support original (which is fit) and fill video scaling modes
- - [ ] Use boot button to switch between video scaling modes while running the roms
- - [ ] Use mute button to toggle volume output while running the roms
+ - [x] Use mute button to toggle volume output while running the roms
+ - [x] Use boot button to switch between video scaling modes while running the roms
  - [ ] FTP Client for browsing remote FTP server of roms and displaying their
        data in LVGL
  - [ ] Feedback through BLDC haptic motor (see
@@ -234,6 +234,7 @@ ESP32s3 Audio Pinout:
 | I2S Data Out   | 15          |
 | I2S Data In    | 16          |
 | Speaker Power  | 46          |
+| Mute Button    | 1           |
 
 I2C Pinout (shared with touchscreen chip above):
 

--- a/components/nofrendo-esp32/video_audio.c
+++ b/components/nofrendo-esp32/video_audio.c
@@ -139,15 +139,24 @@ viddriver_t sdlDriver =
 #define NES_GAME_HEIGHT (224) /* NES_VISIBLE_HEIGHT */
 
 static bool scale_video = false;
+static bool prev_scale_video = false;
 void osd_set_video_scale(bool new_video_scale) {
     scale_video = new_video_scale;
 }
 void ili9341_write_frame_nes(const uint8_t* buffer, uint16_t* myPalette) {
     short x, y;
+    int x_offset = (320-256)/2;
+    int y_offset = (240-224)/2;
     if (buffer == NULL) {
         // clear the buffer, clear the screen
-        lcd_write_frame(0, 0, NES_GAME_WIDTH-1, NES_GAME_HEIGHT-1, NULL);
+        lcd_write_frame(0+x_offset, 0+y_offset, NES_GAME_WIDTH-1, NES_GAME_HEIGHT-1, NULL);
     } else {
+        if (prev_scale_video != scale_video) {
+            // update our local
+            prev_scale_video = scale_video;
+            // clear the frame
+            lcd_write_frame(0,0,320,240,NULL);
+        }
         if (scale_video) {
             uint8_t* framePtr = buffer;
             static int buffer_index = 0;
@@ -169,10 +178,7 @@ void ili9341_write_frame_nes(const uint8_t* buffer, uint16_t* myPalette) {
                     }
                     num_lines_written++;
                 }
-                lcd_write_frame(0, y, 320, num_lines_written, (uint8_t*)&line_buffer[0]);
-
-            }
-            for (y = 0; y < NES_GAME_HEIGHT; y+= LINE_COUNT) {
+                lcd_write_frame(0, y_offset+y, 320, num_lines_written, (uint8_t*)&line_buffer[0]);
             }
         } else {
             uint8_t* framePtr = buffer;
@@ -192,7 +198,7 @@ void ili9341_write_frame_nes(const uint8_t* buffer, uint16_t* myPalette) {
                     }
                     num_lines_written++;
                 }
-                lcd_write_frame(0, y, NES_GAME_WIDTH, num_lines_written, (uint8_t*)&line_buffer[0]);
+                lcd_write_frame(x_offset, y_offset+y, NES_GAME_WIDTH, num_lines_written, (uint8_t*)&line_buffer[0]);
             }
         }
     }

--- a/main/nes.cpp
+++ b/main/nes.cpp
@@ -39,14 +39,6 @@ void set_nes_video_fill() {
 }
 
 void init_nes(const std::string& rom_filename, uint8_t *romdata, size_t rom_data_size) {
-  if (filled) {
-    espp::St7789::set_offset(0, (240 - 224) / 2);
-  } else if (scaled) {
-    espp::St7789::set_offset((320-NES_SCREEN_WIDTH) / 2, (240 - 224) / 2);
-  } else {
-    espp::St7789::set_offset((320-NES_SCREEN_WIDTH) / 2, (240 - 224) / 2);
-  }
-
 #ifdef USE_NES_NOFRENDO
   static bool initialized = false;
   if (!initialized) {


### PR DESCRIPTION
* Added GPIO config for mute button (IO1) and boot button (IO0), with interrupt sending button to task
* Updated UI to allow for querying / setting the video scaling
* Updated UI to break apart mute from volume setting
* Updated NES video loop to properly handle dynamic changes to video scaling
* Updated GB/C video loop to properly handle dynamic changes to video scaling
* Removed offset configuration from display when starting emulators to make it easier to configure / clear when changing video scaling.