### PR TITLE
feat(mmap): remove mmap-ed partition

### DIFF
--- a/components/box-emu-hal/CMakeLists.txt
+++ b/components/box-emu-hal/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
   INCLUDE_DIRS "include"
   SRC_DIRS "src"
-  REQUIRES "driver" "heap" "fatfs" "esp_littlefs" "esp_lcd" "esp_psram" "spi_flash" "nvs_flash" "codec" "display" "display_drivers" "controller" "mcp23x17" "ads1x15" "qwiicnes" "input_drivers" "ft5x06" "tt21100" "drv2605" "event_manager"
+  REQUIRES "driver" "heap" "fatfs" "esp_lcd" "esp_psram" "spi_flash" "nvs_flash" "codec" "display" "display_drivers" "controller" "mcp23x17" "ads1x15" "qwiicnes" "input_drivers" "ft5x06" "tt21100" "drv2605" "event_manager"
   )

--- a/components/box-emu-hal/src/fs_init.cpp
+++ b/components/box-emu-hal/src/fs_init.cpp
@@ -2,42 +2,6 @@
 
 #include "format.hpp"
 
-#if CONFIG_ROM_STORAGE_LITTLEFS
-static esp_vfs_littlefs_conf_t conf = {
-  .base_path = MOUNT_POINT,
-  .partition_label = "littlefs",
-  .format_if_mount_failed = true,
-  .dont_mount = false,
-};
-
-static void littlefs_init() {
-  // Use settings defined above to initialize and mount LittleFS filesystem.
-  // Note: esp_vfs_littlefs_register is an all-in-one convenience function.
-  esp_err_t ret = esp_vfs_littlefs_register(&conf);
-
-  if (ret != ESP_OK) {
-    if (ret == ESP_FAIL) {
-      fmt::print("Failed to mount or format filesystem\n");
-    } else if (ret == ESP_ERR_NOT_FOUND) {
-      fmt::print("Failed to find LittleFS partition\n");
-    } else {
-      fmt::print("Failed to initialize LittleFS ({})\n", esp_err_to_name(ret));
-    }
-    return;
-  }
-
-  size_t total = 0, used = 0;
-  ret = esp_littlefs_info(conf.partition_label, &total, &used);
-  if (ret != ESP_OK) {
-    fmt::print("Failed to get LittleFS partition information ({})\n",
-               esp_err_to_name(ret));
-  } else {
-    fmt::print("Partition size: total: {}, used: {}\n", total, used);
-  }
-}
-#endif
-
-#if CONFIG_ROM_STORAGE_SDCARD
 static void sdcard_init() {
   esp_err_t ret;
 
@@ -105,12 +69,7 @@ static void sdcard_init() {
   // Card has been initialized, print its properties
   sdmmc_card_print_info(stdout, card);
 }
-#endif
 
 void fs_init() {
-#if CONFIG_ROM_STORAGE_LITTLEFS
-  littlefs_init();
-#elif CONFIG_ROM_STORAGE_SDCARD
   sdcard_init();
-#endif
 }

--- a/components/box-emu-hal/src/mmap.cpp
+++ b/components/box-emu-hal/src/mmap.cpp
@@ -1,57 +1,28 @@
 #include "mmap.hpp"
+#include "esp_heap_caps.h"
 
-const esp_partition_t* cart_partition;
-spi_flash_mmap_handle_t hrom;
+static uint8_t* romdata = nullptr;
 
 void init_memory() {
-  // Initialize NVS, needed for BT
-  esp_err_t ret = nvs_flash_init();
-  if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
-    fmt::print("Erasing NVS flash...\n");
-    ESP_ERROR_CHECK(nvs_flash_erase());
-    ret = nvs_flash_init();
-  }
-  ESP_ERROR_CHECK(ret);
-
-  // get the romdata (cart) partition, type 0x40, subtype 1 (partitions.csv)
-  cart_partition = esp_partition_find_first((esp_partition_type_t)0x40, (esp_partition_subtype_t)1, NULL);
-  if (!cart_partition) {
-    fmt::print(fg(fmt::color::red), "Couldn't find cart_partition!\n");
+  // allocate memory for the ROM and make sure it's on the SPIRAM
+  romdata = (uint8_t*)heap_caps_malloc(4*1024*1024, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
+  if (romdata == nullptr) {
+    fmt::print(fg(fmt::terminal_color::red), "ERROR: Couldn't allocate memory for ROM!\n");
   }
 }
 
 size_t copy_romdata_to_cart_partition(const std::string& rom_filename) {
-  esp_err_t err;
-  // erase the existing rom (if any) in the cart_partition
-  err = esp_partition_erase_range(cart_partition, 0, cart_partition->size);
-  if (err != ESP_OK) {
-    fmt::print("Couldn't erase cart_partition!\n");
-  }
   // load the file data and iteratively copy it over
   std::ifstream romfile(rom_filename, std::ios::binary | std::ios::ate); //open file at end
   if (!romfile.is_open()) {
     fmt::print("Error: ROM file does not exist\n");
     return 0;
   }
-
   size_t filesize = romfile.tellg(); // get size from current file pointer location;
   romfile.seekg(0, std::ios::beg); //reset file pointer to beginning;
-
-  size_t block_size = 1024*4; // 4K
-  size_t bytes_written = 0;
-  char block[block_size];
-  for (size_t offset=0; offset < filesize; offset += block_size) {
-    size_t read_size = std::min(filesize - offset, block_size);
-    romfile.read(block, read_size);
-    err = esp_partition_write(cart_partition, offset, block, read_size);
-    if (err != ESP_OK) {
-      fmt::print("Couldn't write to cart_partition, offset: {}, read_size: {}!\n", offset, read_size);
-    }
-    bytes_written += read_size;
-  }
-  fmt::print("Copied {} bytes to cart_partition\n", bytes_written);
+  romfile.read((char*)(romdata), filesize);
   romfile.close();
-  return bytes_written;
+  return filesize;
 }
 
 extern "C" uint8_t *osd_getromdata() {
@@ -59,13 +30,6 @@ extern "C" uint8_t *osd_getromdata() {
 }
 
 uint8_t *get_mmapped_romdata() {
-  esp_err_t err;
-  uint8_t* romdata = nullptr;
-  err = esp_partition_mmap(cart_partition, 0, 3*1024*1024, (esp_partition_mmap_memory_t)SPI_FLASH_MMAP_DATA, (const void**)&romdata, &hrom);
-  if (err != ESP_OK) {
-    fmt::print("Couldn't map cart_partition!\n");
-    return nullptr;
-  }
   fmt::print("Initialized. ROM@{}\n", fmt::ptr(romdata));
   return romdata;
 }

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,6 +1,2 @@
 idf_component_register(SRC_DIRS "."
                        INCLUDE_DIRS ".")
-# 'littlefs' is the file system partition label 'flash_data' is the folder with
-# data to flash, and FLASH_IN_PROJECT says to flash it when flashing project
-# littlefs_create_partition_image(littlefs ../flash_data FLASH_IN_PROJECT)
-littlefs_create_partition_image(littlefs ../flash_data)

--- a/partitions.csv
+++ b/partitions.csv
@@ -1,6 +1,4 @@
 # Name,   Type, SubType, Offset,  Size
 nvs,      data, nvs,     0x9000,  0x6000
 phy_init, data, phy,     0xf000,  0x1000
-factory,  app,  factory, 0x10000, 4M
-nesgame,  0x40, 0x01,           , 0x300000
-littlefs, data, spiffs,         , 8M
+factory,  app,  factory, 0x10000, 6M


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Remove littlefs for the filesystem (only use uSD from now on)
* Remove parititon for cart data
* Change to using a SPIRAM heap-allocated 4MB memory sector for the cart instead of the partition
* Read the whole cart into ram in one call (speeds up rom loading)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Simplifies code, removes unused dependencies, and speeds up cart loading (by doing it all at once into the SPIRAM).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the main code, tested with GBC cart (large), GB cart, and NES carts.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
