### PR TITLE
bug(display): fix spi transmit failure

### DIFF
--- a/components/box-emu-hal/src/spi_lcd.cpp
+++ b/components/box-emu-hal/src/spi_lcd.cpp
@@ -27,7 +27,7 @@ static constexpr int DC_PIN_NUM = 4;
 // This function is called (in irq context!) just before a transmission starts.
 // It will set the D/C line to the value indicated in the user field
 // (DC_LEVEL_BIT).
-static void IRAM_ATTR lcd_spi_pre_transfer_callback(spi_transaction_t *t)
+static void lcd_spi_pre_transfer_callback(spi_transaction_t *t)
 {
     uint32_t user_flags = (uint32_t)(t->user);
     bool dc_level = user_flags & DC_LEVEL_BIT;
@@ -37,7 +37,7 @@ static void IRAM_ATTR lcd_spi_pre_transfer_callback(spi_transaction_t *t)
 // This function is called (in irq context!) just after a transmission ends. It
 // will indicate to lvgl that the next flush is ready to be done if the
 // FLUSH_BIT is set.
-static void IRAM_ATTR lcd_spi_post_transfer_callback(spi_transaction_t *t)
+static void lcd_spi_post_transfer_callback(spi_transaction_t *t)
 {
     uint16_t user_flags = (uint32_t)(t->user);
     bool should_flush = user_flags & FLUSH_BIT;
@@ -47,7 +47,7 @@ static void IRAM_ATTR lcd_spi_post_transfer_callback(spi_transaction_t *t)
     }
 }
 
-extern "C" void IRAM_ATTR lcd_write(const uint8_t *data, size_t length, uint32_t user_data) {
+extern "C" void lcd_write(const uint8_t *data, size_t length, uint32_t user_data) {
     if (length == 0) {
         return;
     }
@@ -80,7 +80,7 @@ static void lcd_wait_lines() {
     }
 }
 
-extern "C" void IRAM_ATTR lcd_send_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data) {
+extern "C" void lcd_send_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data) {
     // if we haven't waited by now, wait here...
     lcd_wait_lines();
     esp_err_t ret;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Remove IRAM_ATTR from lcd write functions, has no effect on the speed, but improves stability

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #12
Originally had `IRAM_ATTR` on those functions under the assumption that it improved speed, but it did not and actually caused the instability we were seeing.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the main code and running an NES cart first, followed by a GBC cart (and then continuing to run other carts).

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [ ] Software change

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
