### PR TITLE
feat(input): reworked input stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Emulator(s) running on ESP BOX with custom pcb and 3d printed enclosure :)
 
-https://user-images.githubusercontent.com/213467/236730090-56c3bd64-86e4-4b9b-a909-0b363fab4fc6.mp4
+https://github.com/esp-cpp/esp-box-emu/assets/213467/3b77f6bd-4c42-417a-9eb7-a648f31b4008
 
-https://user-images.githubusercontent.com/213467/220791336-eb24116d-0958-4ab7-88bd-f6a5bd6d7eb1.mp4
+https://user-images.githubusercontent.com/213467/236730090-56c3bd64-86e4-4b9b-a909-0b363fab4fc6.mp4
 
 As of https://github.com/esp-cpp/esp-box-emu/pull/34 I am starting to add
 initial support for the new ESP32-S3-BOX-3.
@@ -237,6 +237,8 @@ I2C Pinout (shared with touchscreen chip above):
 * [DIY Gameboy](https://learn.adafruit.com/pigrrl-raspberry-pi-gameboy/overview)
 
 ## Videos
+
+https://user-images.githubusercontent.com/213467/220791336-eb24116d-0958-4ab7-88bd-f6a5bd6d7eb1.mp4
 
 ### Gameboy Color
 

--- a/components/box-emu-hal/CMakeLists.txt
+++ b/components/box-emu-hal/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
   INCLUDE_DIRS "include"
   SRC_DIRS "src"
-  REQUIRES "driver" "heap" "fatfs" "esp_lcd" "esp_psram" "spi_flash" "nvs_flash" "codec" "display" "display_drivers" "mcp23x17" "input_drivers" "tt21100" "gt911" "drv2605" "event_manager" "i2c"
+  REQUIRES "driver" "heap" "fatfs" "esp_lcd" "esp_psram" "spi_flash" "nvs_flash" "codec" "display" "display_drivers" "mcp23x17" "input_drivers" "tt21100" "gt911" "drv2605" "event_manager" "i2c" "task" "timer"
   )

--- a/components/box-emu-hal/include/input.h
+++ b/components/box-emu-hal/include/input.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "lvgl.h"
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -21,6 +23,7 @@ extern "C"
 
   void init_input();
   void get_input_state(struct InputState *state);
+  lv_indev_t *get_keypad_input_device();
   void touchpad_read(unsigned char *num_touch_points, unsigned short* x, unsigned short* y, unsigned char* btn_state);
 
 #ifdef __cplusplus

--- a/components/box-emu-hal/src/input.cpp
+++ b/components/box-emu-hal/src/input.cpp
@@ -48,8 +48,8 @@ void keypad_read(bool *up, bool *down, bool *left, bool *right, bool *enter, boo
   *left = state.left;
   *right = state.right;
 
-  *enter = state.a;
-  *escape = state.b;
+  *enter = state.a || state.start;
+  *escape = state.b || state.select;
 }
 
 void update_touchpad_input() {

--- a/components/box-emu-hal/src/input.cpp
+++ b/components/box-emu-hal/src/input.cpp
@@ -23,7 +23,7 @@ static std::shared_ptr<espp::Mcp23x17> mcp23x17;
 static std::shared_ptr<TouchDriver> touch_driver;
 static std::shared_ptr<espp::TouchpadInput> touchpad;
 static std::shared_ptr<espp::KeypadInput> keypad;
-static std::shared_ptr<espp::Timer> gamepad_timer;
+static std::shared_ptr<espp::Timer> input_timer;
 static struct InputState gamepad_state;
 static std::mutex gamepad_state_mutex;
 static TouchpadData touchpad_data;
@@ -180,7 +180,7 @@ void init_input() {
     });
 
   fmt::print("Initializing input task\n");
-  gamepad_timer = std::make_shared<espp::Timer>(espp::Timer::Config{
+  input_timer = std::make_shared<espp::Timer>(espp::Timer::Config{
       .name = "Input timer",
       .period = 20ms,
       .callback = []() {

--- a/components/box-emu-hal/src/input.cpp
+++ b/components/box-emu-hal/src/input.cpp
@@ -1,38 +1,133 @@
+#include <mutex>
+
 #include "input.h"
 
 #include "hal_i2c.hpp"
 
-#include "task.hpp"
-
 #include "mcp23x17.hpp"
-
+#include "timer.hpp"
 #include "touchpad_input.hpp"
+#include "keypad_input.hpp"
 
 using namespace std::chrono_literals;
 using namespace box_hal;
 
+struct TouchpadData {
+  uint8_t num_touch_points = 0;
+  uint16_t x = 0;
+  uint16_t y = 0;
+  uint8_t btn_state = 0;
+};
+
 static std::shared_ptr<espp::Mcp23x17> mcp23x17;
 static std::shared_ptr<TouchDriver> touch_driver;
 static std::shared_ptr<espp::TouchpadInput> touchpad;
+static std::shared_ptr<espp::KeypadInput> keypad;
+static std::shared_ptr<espp::Timer> gamepad_timer;
+static struct InputState gamepad_state;
+static std::mutex gamepad_state_mutex;
+static TouchpadData touchpad_data;
+static std::mutex touchpad_data_mutex;
 
 /**
  * Touch Controller configuration
  */
 void touchpad_read(uint8_t* num_touch_points, uint16_t* x, uint16_t* y, uint8_t* btn_state) {
-  *num_touch_points = 0;
+  std::lock_guard<std::mutex> lock(touchpad_data_mutex);
+  *num_touch_points = touchpad_data.num_touch_points;
+  *x = touchpad_data.x;
+  *y = touchpad_data.y;
+  *btn_state = touchpad_data.btn_state;
+}
+
+void keypad_read(bool *up, bool *down, bool *left, bool *right, bool *enter, bool *escape) {
+  InputState state;
+  get_input_state(&state);
+  *up = state.up;
+  *down = state.down;
+  *left = state.left;
+  *right = state.right;
+
+  *enter = state.a;
+  *escape = state.b;
+}
+
+void update_touchpad_input() {
   // get the latest data from the device
   std::error_code ec;
   bool new_data = touch_driver->update(ec);
   if (ec) {
     fmt::print("error updating touch_driver: {}\n", ec.message());
+    std::lock_guard<std::mutex> lock(touchpad_data_mutex);
+    touchpad_data = {};
     return;
   }
   if (!new_data) {
+    std::lock_guard<std::mutex> lock(touchpad_data_mutex);
+    touchpad_data = {};
     return;
   }
-  // now hand it off
-  touch_driver->get_touch_point(num_touch_points, x, y);
-  *btn_state = touch_driver->get_home_button_state();
+  // get the latest data from the touchpad
+  TouchpadData temp_data;
+  touch_driver->get_touch_point(&temp_data.num_touch_points, &temp_data.x, &temp_data.y);
+  temp_data.btn_state = touch_driver->get_home_button_state();
+  // update the touchpad data
+  std::lock_guard<std::mutex> lock(touchpad_data_mutex);
+  touchpad_data = temp_data;
+}
+
+void update_gamepad_input() {
+  bool is_a_pressed = false;
+  bool is_b_pressed = false;
+  bool is_x_pressed = false;
+  bool is_y_pressed = false;
+  bool is_select_pressed = false;
+  bool is_start_pressed = false;
+  bool is_up_pressed = false;
+  bool is_down_pressed = false;
+  bool is_left_pressed = false;
+  bool is_right_pressed = false;
+  if (!mcp23x17) {
+    fmt::print("cannot get input state: mcp23x17 not initialized properly!\n");
+    return;
+  }
+  // pins are active low
+  // start, select = A0, A1
+  std::error_code ec;
+  auto a_pins = mcp23x17->get_pins(espp::Mcp23x17::Port::A, ec);
+  if (ec) {
+    fmt::print("error getting pins from mcp23x17: {}\n", ec.message());
+    return;
+  }
+  // d-pad, abxy = B0-B3, B4-B7
+  auto b_pins = mcp23x17->get_pins(espp::Mcp23x17::Port::B, ec);
+  if (ec) {
+    fmt::print("error getting pins from mcp23x17: {}\n", ec.message());
+    return;
+  }
+  is_a_pressed = !(b_pins & 1<<4);
+  is_b_pressed = !(b_pins & 1<<5);
+  is_x_pressed = !(b_pins & 1<<6);
+  is_y_pressed = !(b_pins & 1<<7);
+  is_start_pressed = !(a_pins & 1<<0);
+  is_select_pressed = !(a_pins & 1<<1);
+  is_up_pressed = !(b_pins & 1<<0);
+  is_down_pressed = !(b_pins & 1<<1);
+  is_left_pressed = !(b_pins & 1<<2);
+  is_right_pressed = !(b_pins & 1<<3);
+  {
+    std::lock_guard<std::mutex> lock(gamepad_state_mutex);
+    gamepad_state.a = is_a_pressed;
+    gamepad_state.b = is_b_pressed;
+    gamepad_state.x = is_x_pressed;
+    gamepad_state.y = is_y_pressed;
+    gamepad_state.start = is_start_pressed;
+    gamepad_state.select = is_select_pressed;
+    gamepad_state.up = is_up_pressed;
+    gamepad_state.down = is_down_pressed;
+    gamepad_state.left = is_left_pressed;
+    gamepad_state.right = is_right_pressed;
+  }
 }
 
 static std::atomic<bool> initialized = false;
@@ -78,56 +173,35 @@ void init_input() {
       .log_level = espp::Logger::Verbosity::WARN
     });
 
+  fmt::print("Initializing keypad\n");
+  keypad = std::make_shared<espp::KeypadInput>(espp::KeypadInput::Config{
+      .read = keypad_read,
+      .log_level = espp::Logger::Verbosity::WARN
+    });
+
+  fmt::print("Initializing input task\n");
+  gamepad_timer = std::make_shared<espp::Timer>(espp::Timer::Config{
+      .name = "Input timer",
+      .period = 20ms,
+      .callback = []() {
+        update_touchpad_input();
+        update_gamepad_input();
+        return false;
+      },
+      .log_level = espp::Logger::Verbosity::WARN});
+
   initialized = true;
 }
 
+extern "C" lv_indev_t *get_keypad_input_device() {
+  if (!keypad) {
+    fmt::print("cannot get keypad input device: keypad not initialized properly!\n");
+    return nullptr;
+  }
+  return keypad->get_input_device();
+}
+
 extern "C" void get_input_state(struct InputState* state) {
-  bool is_a_pressed = false;
-  bool is_b_pressed = false;
-  bool is_x_pressed = false;
-  bool is_y_pressed = false;
-  bool is_select_pressed = false;
-  bool is_start_pressed = false;
-  bool is_up_pressed = false;
-  bool is_down_pressed = false;
-  bool is_left_pressed = false;
-  bool is_right_pressed = false;
-  if (!mcp23x17) {
-    fmt::print("cannot get input state: mcp23x17 not initialized properly!\n");
-    return;
-  }
-  // pins are active low
-  // start, select = A0, A1
-  std::error_code ec;
-  auto a_pins = mcp23x17->get_pins(espp::Mcp23x17::Port::A, ec);
-  if (ec) {
-    fmt::print("error getting pins from mcp23x17: {}\n", ec.message());
-    return;
-  }
-  // d-pad, abxy = B0-B3, B4-B7
-  auto b_pins = mcp23x17->get_pins(espp::Mcp23x17::Port::B, ec);
-  if (ec) {
-    fmt::print("error getting pins from mcp23x17: {}\n", ec.message());
-    return;
-  }
-  is_a_pressed = !(b_pins & 1<<4);
-  is_b_pressed = !(b_pins & 1<<5);
-  is_x_pressed = !(b_pins & 1<<6);
-  is_y_pressed = !(b_pins & 1<<7);
-  is_start_pressed = !(a_pins & 1<<0);
-  is_select_pressed = !(a_pins & 1<<1);
-  is_up_pressed = !(b_pins & 1<<0);
-  is_down_pressed = !(b_pins & 1<<1);
-  is_left_pressed = !(b_pins & 1<<2);
-  is_right_pressed = !(b_pins & 1<<3);
-  state->a = is_a_pressed;
-  state->b = is_b_pressed;
-  state->x = is_x_pressed;
-  state->y = is_y_pressed;
-  state->start = is_start_pressed;
-  state->select = is_select_pressed;
-  state->up = is_up_pressed;
-  state->down = is_down_pressed;
-  state->left = is_left_pressed;
-  state->right = is_right_pressed;
+  std::lock_guard<std::mutex> lock(gamepad_state_mutex);
+  *state = gamepad_state;
 }

--- a/components/gui/include/gui.hpp
+++ b/components/gui/include/gui.hpp
@@ -214,6 +214,9 @@ protected:
   std::atomic<int> focused_rom_{-1};
   lv_img_dsc_t focused_boxart_;
 
+  // style for buttons
+  lv_style_t button_style_;
+
   lv_anim_t rom_label_animation_template_;
   lv_style_t rom_label_style_;
 

--- a/components/gui/include/gui.hpp
+++ b/components/gui/include/gui.hpp
@@ -10,6 +10,7 @@
 #include "task.hpp"
 #include "logger.hpp"
 
+#include "input.h"
 #include "hal_events.hpp"
 #include "i2s_audio.h"
 #include "video_setting.hpp"
@@ -82,39 +83,13 @@ public:
 
   void pause() {
     paused_ = true;
+    freeze_focus();
   }
   void resume() {
     update_shared_state();
     paused_ = false;
+    focus_rommenu();
   }
-
-  void next() {
-    // protect since this function is called from another thread context
-    std::lock_guard<std::recursive_mutex> lk(mutex_);
-    if (roms_.size() == 0) {
-      return;
-    }
-    // focus the next rom
-    focused_rom_++;
-    if (focused_rom_ >= roms_.size()) focused_rom_ = 0;
-    auto rom = roms_[focused_rom_];
-    focus_rom(rom);
-  }
-
-  void previous() {
-    // protect since this function is called from another thread context
-    std::lock_guard<std::recursive_mutex> lk(mutex_);
-    if (roms_.size() == 0) {
-      return;
-    }
-    // focus the previous rom
-    focused_rom_--;
-    if (focused_rom_ < 0) focused_rom_ = roms_.size() - 1;
-    auto rom = roms_[focused_rom_];
-    focus_rom(rom);
-  }
-
-  void focus_rom(lv_obj_t *new_focus, bool scroll_to_view=true);
 
   void set_haptic_waveform(int new_waveform) {
     if (new_waveform > 123) {
@@ -141,7 +116,12 @@ protected:
   void init_ui();
   void deinit_ui();
 
+  void freeze_focus();
+  void focus_rommenu();
+  void focus_settings();
+
   void load_rom_screen();
+  void load_settings_screen();
 
   void update_shared_state() {
     set_mute(is_muted());
@@ -150,6 +130,8 @@ protected:
   }
 
   VideoSetting get_video_setting();
+
+  void on_rom_focused(lv_obj_t *new_focus);
 
   void on_mute_button_pressed(const std::vector<uint8_t>& data) {
     set_mute(is_muted());
@@ -203,6 +185,7 @@ protected:
     case LV_EVENT_SHORT_CLICKED:
       break;
     case LV_EVENT_PRESSED:
+    case LV_EVENT_CLICKED:
       gui->on_pressed(e);
       break;
     case LV_EVENT_VALUE_CHANGED:
@@ -211,6 +194,10 @@ protected:
     case LV_EVENT_LONG_PRESSED:
       break;
     case LV_EVENT_KEY:
+      gui->on_key(e);
+      break;
+    case LV_EVENT_FOCUSED:
+      gui->on_rom_focused(lv_event_get_target(e));
       break;
     default:
       break;
@@ -219,6 +206,7 @@ protected:
 
   void on_pressed(lv_event_t *e);
   void on_value_changed(lv_event_t *e);
+  void on_key(lv_event_t *e);
 
   // LVLG gui objects
   std::vector<std::string> boxart_paths_;
@@ -228,6 +216,9 @@ protected:
 
   lv_anim_t rom_label_animation_template_;
   lv_style_t rom_label_style_;
+
+  lv_group_t *rom_screen_group_;
+  lv_group_t *settings_screen_group_;
 
   Jpeg decoder_;
 

--- a/components/gui/src/gui.cpp
+++ b/components/gui/src/gui.cpp
@@ -2,6 +2,7 @@
 
 extern "C" {
 #include "ui.h"
+#include "ui_helpers.h"
 #include "ui_comp.h"
 }
 
@@ -128,6 +129,7 @@ void Gui::init_ui() {
 
   // rom screen navigation
   lv_obj_add_event_cb(ui_settingsbutton, &Gui::event_callback, LV_EVENT_PRESSED, static_cast<void*>(this));
+  lv_obj_add_event_cb(ui_closebutton, &Gui::event_callback, LV_EVENT_PRESSED, static_cast<void*>(this));
   lv_obj_add_event_cb(ui_playbutton, &Gui::event_callback, LV_EVENT_PRESSED, static_cast<void*>(this));
 
   // video settings
@@ -171,13 +173,13 @@ void Gui::init_ui() {
 
 void Gui::load_rom_screen() {
   logger_.info("Loading rom screen");
-  lv_scr_load(ui_romscreen);
+  _ui_screen_change( ui_romscreen, LV_SCR_LOAD_ANIM_MOVE_LEFT, 100, 0);
   focus_rommenu();
 }
 
 void Gui::load_settings_screen() {
   logger_.info("Loading settings screen");
-  lv_scr_load(ui_settingsscreen);
+  _ui_screen_change( ui_settingsscreen, LV_SCR_LOAD_ANIM_MOVE_RIGHT, 100, 0);
   focus_settings();
 }
 
@@ -199,7 +201,7 @@ void Gui::on_pressed(lv_event_t *e) {
   bool is_settings_button = (target == ui_settingsbutton);
   if (is_settings_button) {
     // set the settings screen group as the default group
-    lv_group_set_default(settings_screen_group_);
+    focus_settings();
     return;
   }
   // volume controls
@@ -239,6 +241,11 @@ void Gui::on_pressed(lv_event_t *e) {
   if (is_play_button) {
     ready_to_play_ = true;
     freeze_focus();
+    return;
+  }
+  bool is_close_button = (target == ui_closebutton);
+  if (is_close_button) {
+    focus_rommenu();
     return;
   }
   // or is it one of the roms?

--- a/components/gui/src/gui.cpp
+++ b/components/gui/src/gui.cpp
@@ -168,6 +168,22 @@ void Gui::init_ui() {
   lv_group_add_obj(settings_screen_group_, ui_hapticupbutton);
   lv_group_add_obj(settings_screen_group_, ui_hapticplaybutton);
 
+  // set the focused style for all the buttons to have a red border
+  lv_style_init(&button_style_);
+  lv_style_set_border_color(&button_style_, lv_palette_main(LV_PALETTE_RED));
+  lv_style_set_border_width(&button_style_, 2);
+
+  lv_obj_add_style(ui_settingsbutton, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_playbutton, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_closebutton, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_volumeupbutton, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_volumedownbutton, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_mutebutton, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_hapticupbutton, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_hapticdownbutton, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_hapticplaybutton, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_videosettingdropdown, &button_style_, LV_STATE_FOCUSED);
+
   focus_rommenu();
 }
 

--- a/components/menu/include/menu.hpp
+++ b/components/menu/include/menu.hpp
@@ -172,9 +172,10 @@ protected:
   void on_value_changed(lv_event_t *e);
   void on_key(lv_event_t *e);
 
+  // LVLG menu objects
+  lv_style_t button_style_;
   lv_group_t *group_{nullptr};
 
-  // LVLG menu objects
   lv_img_dsc_t state_image_;
   lv_img_dsc_t paused_image_;
 

--- a/components/menu/include/menu.hpp
+++ b/components/menu/include/menu.hpp
@@ -9,6 +9,7 @@
 #include "task.hpp"
 #include "logger.hpp"
 
+#include "input.h"
 #include "hal_events.hpp"
 #include "i2s_audio.h"
 #include "video_setting.hpp"
@@ -95,12 +96,16 @@ public:
   void set_video_setting(VideoSetting setting);
 
   bool is_paused() { return paused_; }
-  void pause() { paused_ = true; }
+  void pause() {
+    paused_ = true;
+    lv_group_focus_freeze(group_, true);
+  }
   void resume() {
     update_shared_state();
     update_slot_display();
     update_pause_image();
     paused_ = false;
+    lv_group_focus_freeze(group_, false);
   }
 
 protected:
@@ -156,6 +161,7 @@ protected:
     case LV_EVENT_LONG_PRESSED:
       break;
     case LV_EVENT_KEY:
+      menu->on_key(e);
       break;
     default:
       break;
@@ -164,6 +170,9 @@ protected:
 
   void on_pressed(lv_event_t *e);
   void on_value_changed(lv_event_t *e);
+  void on_key(lv_event_t *e);
+
+  lv_group_t *group_{nullptr};
 
   // LVLG menu objects
   lv_img_dsc_t state_image_;

--- a/components/menu/src/menu.cpp
+++ b/components/menu/src/menu.cpp
@@ -68,6 +68,23 @@ void Menu::init_ui() {
   lv_group_add_obj(group_, ui_reset_btn);
   lv_group_add_obj(group_, ui_quit_btn);
 
+  // set the focused style for all the buttons to have a red border
+  lv_style_init(&button_style_);
+  lv_style_set_border_color(&button_style_, lv_palette_main(LV_PALETTE_RED));
+  lv_style_set_border_width(&button_style_, 2);
+
+  lv_obj_add_style(ui_resume_btn, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_volume_mute_btn, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_volume_dec_btn, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_volume_inc_btn, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_btn_slot_dec, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_btn_slot_inc, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_load_btn, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_save_btn, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_Dropdown2, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_reset_btn, &button_style_, LV_STATE_FOCUSED);
+  lv_obj_add_style(ui_quit_btn, &button_style_, LV_STATE_FOCUSED);
+
   // now focus the resume button
   lv_group_focus_obj(ui_resume_btn);
   lv_group_focus_freeze(group_, false);

--- a/main/cart.hpp
+++ b/main/cart.hpp
@@ -163,10 +163,17 @@ public:
   virtual bool run() {
     running_ = true;
     // handle touchpad so we can know if the user presses the menu
-    uint8_t _num_touches, _btn_state;
-    uint16_t _x,_y;
+    uint8_t _num_touches = 0, _btn_state = false;
+    uint16_t _x = 0 ,_y = 0;
     touchpad_read(&_num_touches, &_x, &_y, &_btn_state);
-    if (_btn_state) {
+    // also get the gamepad input state so we can know if the user presses the
+    // start/select buttons together to bring up the menu
+    InputState state;
+    get_input_state(&state);
+    // if the user presses the menu button or the start/select buttons, then
+    // pause the game and show the menu
+    bool show_menu = _btn_state || (state.start && state.select);
+    if (show_menu) {
       logger_.warn("Menu pressed!");
       pre_menu();
       // take a screenshot before we show the menu

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -36,7 +36,7 @@ extern std::shared_ptr<espp::Display> display;
 
 using namespace std::chrono_literals;
 
-bool operator==(const InputState& lhs, const InputState& rhs) {
+static bool operator==(const InputState& lhs, const InputState& rhs) {
   return
     lhs.a == rhs.a &&
     lhs.b == rhs.b &&
@@ -133,26 +133,7 @@ extern "C" void app_main(void) {
   while (true) {
     // reset gui ready to play and user_quit
     gui.ready_to_play(false);
-
-    struct InputState prev_state;
-    struct InputState curr_state;
-    get_input_state(&prev_state);
-    get_input_state(&curr_state);
     while (!gui.ready_to_play()) {
-      // TODO: would be better to make this an actual LVGL input device instead
-      // of this..
-      get_input_state(&curr_state);
-      if (curr_state != prev_state) {
-        prev_state = curr_state;
-        if (curr_state.up) {
-          gui.previous();
-        } else if (curr_state.down) {
-          gui.next();
-        } else if (curr_state.start) {
-          // same as play button was pressed, just exit the loop!
-          break;
-        }
-      }
       std::this_thread::sleep_for(50ms);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Have touchscreen and gamepad input run consistently, within its own task - so that the getter functions merely return the latest data for more consistent performance and to enable more reuse throughout the code
* Update espp submodule to have latest code including keypad_driver
* Update gui and menu to support the new keypad driver (including the kludge around how we have to deal with the dropdowns)
* Update cart to allow start+select to show the menu
* Update main to remove old code for allowing gamepad input only on rom menu since its now supported everywhere
* Update buttons to have red outline when focused to make it easier to see which button the gamepad input is on

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Right now you have to use the touchscreen to change any of the settings and to manage the emulation controls (pause) menu when playing roms. This is less than ideal since we have perfectly fine buttons and your hands are already on the buttons.

This PR enables full support for using the gamepad to control the UI. Note: when running a rom, pressing `start + select` together will trigger the controls / menu, just like pressing the touchscreen's home button does. Of course, the touch controls are still functional should you wish to use them.

Associated PR from espp: https://github.com/esp-cpp/espp/pull/125

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running on the box-emu (running on ESP32-S3-BOX). Tested 
- rom menu navigation (`up/down/left/right`)
- rom activation (pressing `a` when on a rom)
- opening the settings menu (pressing `b` while on the rom menu)
- navigating the settings menu (`up/down/left/right`)
- changing settings (`a` to activate buttons and to open / select dropdowns, `b` to close dropdowns and to return to rom menu)
- Opening the emulation controls menu (pressing `start+select` simultaneously)
- navigating the emulation controls menu (`up/down/left/right`)
- Changing settings (`a` to activate buttons and to open / select dropdowns, `b` to close dropdowns and to return to the game)

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

https://github.com/esp-cpp/esp-box-emu/assets/213467/3b77f6bd-4c42-417a-9eb7-a648f31b4008

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.