### PR TITLE
fix(sms): fix palette index issue when taking screenshots

### DIFF
--- a/components/sms/src/sms.cpp
+++ b/components/sms/src/sms.cpp
@@ -223,7 +223,7 @@ std::vector<uint8_t> get_sms_video_buffer() {
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {
       uint8_t index = frame_buffer[y * pitch + x];
-      uint16_t rgb565 = palette[index];
+      uint16_t rgb565 = palette[index % PALETTE_SIZE];
       frame[(y * width + x)*2] = rgb565 & 0xFF;
       frame[(y * width + x)*2+1] = (rgb565 >> 8) & 0xFF;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use the palette size when indexing into the palette for taking a screenshot.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We'd like the screenshot to exactly reflect the correct state of the game and what is on screen.

Example of how it is now:
![image](https://github.com/esp-cpp/esp-box-emu/assets/213467/efd6ac3a-9602-495a-887e-7d611ad35f39)


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Pausing emulation and looking at the screenshots in both SMS and GG games.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![image](https://github.com/esp-cpp/esp-box-emu/assets/213467/999e225b-a610-4302-9138-f8a107b3dcbb)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.