### PR TITLE
fix(nes): remove sleep during run for better audio

### DIFF
--- a/components/gbc/src/gameboy.cpp
+++ b/components/gbc/src/gameboy.cpp
@@ -115,9 +115,6 @@ void run_to_vblank() {
   auto end = std::chrono::high_resolution_clock::now();
   auto elapsed = std::chrono::duration<float>(end-start).count();
   update_frame_time(elapsed);
-  // frame rate should be 60 FPS, so 1/60th second is what we want to sleep for
-  static constexpr auto delay = std::chrono::duration<float>(1.0f/60.0f);
-  std::this_thread::sleep_until(start + delay);
 }
 
 void reset_gameboy() {

--- a/components/nes/src/nes.cpp
+++ b/components/nes/src/nes.cpp
@@ -61,9 +61,6 @@ void run_nes_rom() {
   auto end = std::chrono::high_resolution_clock::now();
   auto elapsed = std::chrono::duration<float>(end-start).count();
   update_frame_time(elapsed);
-  // frame rate should be 60 FPS, so 1/60th second is what we want to sleep for
-  static constexpr auto delay = std::chrono::duration<float>(1.0f/60.0f);
-  std::this_thread::sleep_until(start + delay);
 }
 
 void load_nes(std::string_view save_path) {

--- a/components/sms/src/sms.cpp
+++ b/components/sms/src/sms.cpp
@@ -192,9 +192,6 @@ void run_sms_rom() {
   auto end = std::chrono::high_resolution_clock::now();
   auto elapsed = std::chrono::duration<float>(end-start).count();
   update_frame_time(elapsed);
-  // frame rate should be 60 FPS, so 1/60th second is what we want to sleep for
-  static constexpr auto delay = std::chrono::duration<float>(1.0f/60.0f);
-  std::this_thread::sleep_until(start + delay);
 }
 
 void load_sms(std::string_view save_path) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Removed sleep from run_nes_rom, run_sms_rom, and run_gameboy_rom since the sleep does not affect performance but it degrades sound (specifically on NES)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Audio on NES wasn't perfect (some audio artifacts / pops), but simply removing the sleep fixes it. I went ahead and removed the associated sleeps within the GBC and SMS components as well.

NOTE: this decreases the measured FPS to 60 on all platforms, but doesn't seem to affect their performance.

Thanks to @danialre for finding out the fix (removing the sleep) over at his fork: 
https://github.com/danialre/saintcon2023-emu

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running on Hardware V0 and playing NES, GBC, and SMS/GG roms.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.