### PR TITLE
feat(genesis): disable sound emulation when muted for better performance

### DIFF
--- a/components/genesis/src/genesis.cpp
+++ b/components/genesis/src/genesis.cpp
@@ -216,14 +216,16 @@ void run_genesis_rom() {
 
   gwenesis_vdp_render_config();
 
+  bool sound_enabled = !hal::is_muted();
+
   /* Reset the difference clocks and audio index */
   system_clock = 0;
-  zclk = 0; // z80_enabled ? 0 : 0x1000000;
+  zclk = sound_enabled ? 0 : 0x1000000;
 
-  ym2612_clock = 0; // yfm_enabled ? 0 : 0x1000000;
+  ym2612_clock = sound_enabled ? 0 : 0x1000000;
   ym2612_index = 0;
 
-  sn76489_clock = 0; // sn76489_enabled ? 0 : 0x1000000;
+  sn76489_clock = sound_enabled ? 0 : 0x1000000;
   sn76489_index = 0;
 
   scan_line = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since genesis emulation is currently slow, disable sound emulation when sound output is muted for more playable framerates.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running on Box-3 and playing sonic. See #60 video for reference.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.