### PR TITLE
fix(touch): Initialize touch after display so it works with lvgl

### DIFF
--- a/components/box-emu/src/box-emu.cpp
+++ b/components/box-emu/src/box-emu.cpp
@@ -37,11 +37,6 @@ espp::I2c &BoxEmu::external_i2c() {
 bool BoxEmu::initialize_box() {
   logger_.info("Initializing EspBox");
   auto &box = espp::EspBox::get();
-  // initialize the touchpad
-  if (!box.initialize_touch()) {
-    logger_.error("Failed to initialize touchpad!");
-    return false;
-  }
   // initialize the sound
   if (!box.initialize_sound()) {
     logger_.error("Failed to initialize sound!");
@@ -56,6 +51,11 @@ bool BoxEmu::initialize_box() {
   // initialize the LVGL display for the esp-box
   if (!box.initialize_display(pixel_buffer_size)) {
     logger_.error("Failed to initialize display!");
+    return false;
+  }
+  // initialize the touchpad
+  if (!box.initialize_touch()) {
+    logger_.error("Failed to initialize touchpad!");
     return false;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Initializes the touchpad after the display, ensuring it's properly configured with LVGL so that all UI touch items work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Touchscreen is nice, even if the gamepad is usually more convenient.

If the touchscreen is initialized before the display, then it's technically initialized before lvgl is initialized, which means the connection to lvgl will silently fail.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and testing `main` on a Box-3 Emu V1 and testing to make sure the touchscreen still works 😅 

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [ ] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.