### PR TITLE
ci: Update atopile action to only upload box-emu and box-3-emu files and zip them

### DIFF
--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -21,15 +21,34 @@ jobs:
         with:
           path: 'ecad/'  # atopile project directory
 
-      - name: Upload Combined Artifacts
+      - name: Zip up box-emu files
+        run: |
+          cd ecad
+          # zip all files which match box-emu.* or box-emu-gerbers*.zip
+          zip -r build/box-emu.zip box-emu.* box-emu-gerbers*.zip
+          cd ..
+
+      - name: Zip up box-3-emu files
+        run: |
+          cd ecad
+          # zip all files which match box-3-emu.* or box-3-emu-gerbers*.zip
+          zip -r build/box-3-emu.zip box-3-emu.* box-3-emu-gerbers*.zip
+          cd ..
+
+      - name: Upload Box-3-Emu
         uses: actions/upload-artifact@v4
         with:
-          name: ecad_build
-          path: 'ecad/build' # atopile build directory
+          path: ecad/build/box-3-emu.zip
+
+      - name: Upload Box-Emu
+        uses: actions/upload-artifact@v4
+        with:
+          path: ecad/build/box-emu.zip
 
       - name: Attach files to release
         uses: softprops/action-gh-release@v2
         if: ${{ github.event.release && github.event.action == 'published' }}
         with:
           files: |
-            ecad/build/*
+            ecad/build/box-3-emu.zip
+            ecad/build/box-emu.zip

--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -1,3 +1,5 @@
+name: Electronics Build (Atopile)
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -23,32 +23,32 @@ jobs:
 
       - name: Zip up box-emu files in the build output directory
         run: |
-          cd ecad/build
+          cd ecad
           # zip all files which match box-emu.* or box-emu-gerbers*.zip
-          zip -r box-emu.zip box-emu.* box-emu-gerbers*.zip
+          zip -j -r box-emu.zip build/box-emu.* build/box-emu-gerbers*.zip
           cd ..
 
       - name: Zip up box-3-emu files in the build output directory
         run: |
-          cd ecad/build
+          cd ecad
           # zip all files which match box-3-emu.* or box-3-emu-gerbers*.zip
-          zip -r box-3-emu.zip box-3-emu.* box-3-emu-gerbers*.zip
+          zip -j -r box-3-emu.zip build/box-3-emu.* build/box-3-emu-gerbers*.zip
           cd ..
 
       - name: Upload Box-3-Emu
         uses: actions/upload-artifact@v4
         with:
-          path: ecad/build/box-3-emu.zip
+          path: ecad/box-3-emu.zip
 
       - name: Upload Box-Emu
         uses: actions/upload-artifact@v4
         with:
-          path: ecad/build/box-emu.zip
+          path: ecad/box-emu.zip
 
       - name: Attach files to release
         uses: softprops/action-gh-release@v2
         if: ${{ github.event.release && github.event.action == 'published' }}
         with:
           files: |
-            ecad/build/box-3-emu.zip
-            ecad/build/box-emu.zip
+            ecad/box-3-emu.zip
+            ecad/box-emu.zip

--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -40,12 +40,18 @@ jobs:
       - name: Upload Box-3-Emu
         uses: actions/upload-artifact@v4
         with:
-          path: ecad/box-3-emu.zip
+          name: box-3-emu
+          path: |
+            ecad/build/box-3-emu.*
+            ecad/build/box-3-emu-gerbers*.zip
 
       - name: Upload Box-Emu
         uses: actions/upload-artifact@v4
         with:
-          path: ecad/box-emu.zip
+          name: box-emu
+          path: |
+            ecad/build/box-emu.*
+            ecad/build/box-emu-gerbers*.zip
 
       - name: Attach files to release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -21,18 +21,18 @@ jobs:
         with:
           path: 'ecad/'  # atopile project directory
 
-      - name: Zip up box-emu files
+      - name: Zip up box-emu files in the build output directory
         run: |
-          cd ecad
+          cd ecad/build
           # zip all files which match box-emu.* or box-emu-gerbers*.zip
-          zip -r build/box-emu.zip box-emu.* box-emu-gerbers*.zip
+          zip -r box-emu.zip box-emu.* box-emu-gerbers*.zip
           cd ..
 
-      - name: Zip up box-3-emu files
+      - name: Zip up box-3-emu files in the build output directory
         run: |
-          cd ecad
+          cd ecad/build
           # zip all files which match box-3-emu.* or box-3-emu-gerbers*.zip
-          zip -r build/box-3-emu.zip box-3-emu.* box-3-emu-gerbers*.zip
+          zip -r box-3-emu.zip box-3-emu.* box-3-emu-gerbers*.zip
           cd ..
 
       - name: Upload Box-3-Emu


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Zip up box-emu files and box-3-emu files
* Upload only those two zips and attach them as artifacts
* Do not upload all build output files to release, only the box-emu.zip and box-3-emu.zip

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, all build outputs were uploaded to as an artifact which was a large ecad_build artifact on the commit, and the release contained each file individually (which was really annoying to have to simply download the files you need for the box-emu fabrication or the box-3-emu fabrication.

This PR fixes that by only uploading those files and zipping them so they're a single archive for each build which needs to be downloaded from the release.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This PR