### PR TITLE
ci: update firmware packaging to zip the output into a single archive for upload to release

### DIFF
--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -26,10 +26,15 @@ jobs:
         path: '.'
         command: './patches.sh && idf.py build'
 
+      - name: Zip up firmware binaries
+        run: |
+          # zip the firmware bin files and flash args
+          zip -j -r firmware-binaries.zip build/esp-box-emu.bin build/bootloader/bootloader.bin build/partition_table/partition-table.bin build/flash_args
+
     - name: Upload Build Outputs
       uses: actions/upload-artifact@v4
       with:
-        name: build-artifacts
+        name: firmware-binaries
         path: |
           build/bootloader/bootloader.bin
           build/partition_table/partition-table.bin
@@ -40,9 +45,4 @@ jobs:
       uses: softprops/action-gh-release@v2
       if: ${{ github.event.release && github.event.action == 'published' }}
       with:
-        files: |
-          build/esp-box-emu.bin
-          build/bootloader/bootloader.bin
-          build/partition_table/partition-table.bin
-          build/flash_args
-
+        files: firmware-binaries.zip


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Compress binary firmware output into single zip archive for uploading to release

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #75 - this is basically the fw equivalent, to make it easier to download the firmware related artifacts from the release.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This PR.
