### PR TITLE
Only run atopile action on ecad changes and render 3d image output of ecad

### DIFF
--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -18,7 +18,6 @@ on:
 jobs:
   Atopile:
     runs-on: ubuntu-latest
-    container: ghcr.io/inti-cmnb/kicad7_auto_full:dev
 
     steps:
 
@@ -30,19 +29,11 @@ jobs:
         with:
           path: 'ecad/'  # atopile project directory
 
-      - name: Cache 3D models data
-        id: models-cache
-        uses: set-soft/cache@main
-        with:
-          path: ~/cache_3d
-          key: cache_3d
-
       - name: Render Box-Emu PCB
         uses: INTI-CMNB/KiBot@v2_k7
         with:
           # Required - kibot config file
           config: ecad/config.kibot.yaml
-          cache3D: YES
           # optional - prefix to output defined in config
           dir: 'ecad/kibot-box-emu'
           # optional - PCB design file
@@ -53,7 +44,6 @@ jobs:
         with:
           # Required - kibot config file
           config: ecad/config.kibot.yaml
-          cache3D: YES
           # optional - prefix to output defined in config
           dir: 'ecad/kibot-box-3-emu'
           # optional - PCB design file

--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -30,7 +30,7 @@ jobs:
           path: 'ecad/'  # atopile project directory
 
       - name: Render Box-Emu PCB
-        uses: INTI-CMNB/KiBot@v2
+        uses: INTI-CMNB/KiBot@v2_k7
         with:
           # Required - kibot config file
           config: ecad/config.kibot.yaml
@@ -40,7 +40,7 @@ jobs:
           board: 'ecad/elec/layout/box-emu/box-emu.kicad_pcb'
 
       - name: Render Box-3-Emu PCB
-        uses: INTI-CMNB/KiBot@v2
+        uses: INTI-CMNB/KiBot@v2_k7
         with:
           # Required - kibot config file
           config: ecad/config.kibot.yaml

--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -81,6 +81,14 @@ jobs:
             ecad/build/box-emu-gerbers*.zip
             ecad/kibot-box-emu/*
 
+      - name: Upload Images to PR
+        uses: edunad/actions-image@v2.0.0
+        with:
+            path: 'ecad/kibot-**/*.png'
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            title: 'ECAD Images'
+            annotationLevel: 'notice'
+
       - name: Attach files to release
         uses: softprops/action-gh-release@v2
         if: ${{ github.event.release && github.event.action == 'published' }}

--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -53,14 +53,14 @@ jobs:
         run: |
           cd ecad
           # zip all files which match box-emu.* or box-emu-gerbers*.zip
-          zip -j -r box-emu.zip build/box-emu.* build/box-emu-gerbers*.zip kibot-box-emu/*
+          zip -r box-emu.zip build/box-emu.* build/box-emu-gerbers*.zip kibot-box-emu/*
           cd ..
 
       - name: Zip up box-3-emu files in the build output directory
         run: |
           cd ecad
           # zip all files which match box-3-emu.* or box-3-emu-gerbers*.zip
-          zip -j -r box-3-emu.zip build/box-3-emu.* build/box-3-emu-gerbers*.zip kibot-box-3-emu/*
+          zip -r box-3-emu.zip build/box-3-emu.* build/box-3-emu-gerbers*.zip kibot-box-3-emu/*
           cd ..
 
       - name: Upload Box-3-Emu

--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -3,8 +3,14 @@ name: Electronics Build (Atopile)
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'ecad/*'
+      - '.github/workflows/atopile.yml'
   push:
     branches: [main]
+    paths:
+      - 'ecad/*'
+      - '.github/workflows/atopile.yml'
   release:
     types: [published]
   workflow_dispatch:
@@ -36,6 +42,28 @@ jobs:
           # zip all files which match box-3-emu.* or box-3-emu-gerbers*.zip
           zip -j -r box-3-emu.zip build/box-3-emu.* build/box-3-emu-gerbers*.zip
           cd ..
+
+      - name: Render Box-Emu PCB
+        uses: INTI-CMNB/KiBot@v2_k7
+        with:
+          # Required - kibot config file
+          config: ecad/config.kibot.yaml
+          # optional - prefix to output defined in config
+          dir: 'ecad/build'
+          # optional - PCB design file
+          board: 'ecad/elec/layout/box-emu/box-emu.kicad_pcb'
+          # build the 3d
+          targets: render_3d
+
+      - name: Render Box-3-Emu PCB
+        uses: INTI-CMNB/KiBot@v2_k7
+        with:
+          # Required - kibot config file
+          config: ecad/config.kibot.yaml
+          # optional - prefix to output defined in config
+          dir: 'ecad/build'
+          # optional - PCB design file
+          board: 'ecad/elec/layout/box-3-emu/box-3-emu.kicad_pcb'
 
       - name: Upload Box-3-Emu
         uses: actions/upload-artifact@v4

--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -30,7 +30,7 @@ jobs:
           path: 'ecad/'  # atopile project directory
 
       - name: Render Box-Emu PCB
-        uses: INTI-CMNB/KiBot@v2_k7
+        uses: INTI-CMNB/KiBot@v2
         with:
           # Required - kibot config file
           config: ecad/config.kibot.yaml
@@ -40,7 +40,7 @@ jobs:
           board: 'ecad/elec/layout/box-emu/box-emu.kicad_pcb'
 
       - name: Render Box-3-Emu PCB
-        uses: INTI-CMNB/KiBot@v2_k7
+        uses: INTI-CMNB/KiBot@v2
         with:
           # Required - kibot config file
           config: ecad/config.kibot.yaml

--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -16,8 +16,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  Atopile:
     runs-on: ubuntu-latest
+    container: ghcr.io/inti-cmnb/kicad7_auto_full:dev
 
     steps:
 
@@ -29,13 +30,22 @@ jobs:
         with:
           path: 'ecad/'  # atopile project directory
 
+      - name: Cache 3D models data
+        id: models-cache
+        uses: set-soft/cache@main
+        with:
+          path: ~/cache_3d
+          key: cache_3d
+
       - name: Render Box-Emu PCB
         uses: INTI-CMNB/KiBot@v2_k7
         with:
           # Required - kibot config file
           config: ecad/config.kibot.yaml
+          cache3D: YES
           # optional - prefix to output defined in config
           dir: 'ecad/kibot-box-emu'
+          cache3D: YES
           # optional - PCB design file
           board: 'ecad/elec/layout/box-emu/box-emu.kicad_pcb'
 
@@ -44,6 +54,7 @@ jobs:
         with:
           # Required - kibot config file
           config: ecad/config.kibot.yaml
+          cache3D: YES
           # optional - prefix to output defined in config
           dir: 'ecad/kibot-box-3-emu'
           # optional - PCB design file

--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -45,7 +45,6 @@ jobs:
           cache3D: YES
           # optional - prefix to output defined in config
           dir: 'ecad/kibot-box-emu'
-          cache3D: YES
           # optional - PCB design file
           board: 'ecad/elec/layout/box-emu/box-emu.kicad_pcb'
 

--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -52,8 +52,6 @@ jobs:
           dir: 'ecad/build'
           # optional - PCB design file
           board: 'ecad/elec/layout/box-emu/box-emu.kicad_pcb'
-          # build the 3d
-          targets: render_3d
 
       - name: Render Box-3-Emu PCB
         uses: INTI-CMNB/KiBot@v2_k7

--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -29,20 +29,6 @@ jobs:
         with:
           path: 'ecad/'  # atopile project directory
 
-      - name: Zip up box-emu files in the build output directory
-        run: |
-          cd ecad
-          # zip all files which match box-emu.* or box-emu-gerbers*.zip
-          zip -j -r box-emu.zip build/box-emu.* build/box-emu-gerbers*.zip
-          cd ..
-
-      - name: Zip up box-3-emu files in the build output directory
-        run: |
-          cd ecad
-          # zip all files which match box-3-emu.* or box-3-emu-gerbers*.zip
-          zip -j -r box-3-emu.zip build/box-3-emu.* build/box-3-emu-gerbers*.zip
-          cd ..
-
       - name: Render Box-Emu PCB
         uses: INTI-CMNB/KiBot@v2_k7
         with:
@@ -62,6 +48,20 @@ jobs:
           dir: 'ecad/build'
           # optional - PCB design file
           board: 'ecad/elec/layout/box-3-emu/box-3-emu.kicad_pcb'
+
+      - name: Zip up box-emu files in the build output directory
+        run: |
+          cd ecad
+          # zip all files which match box-emu.* or box-emu-gerbers*.zip
+          zip -j -r box-emu.zip build/box-emu.* build/box-emu-gerbers*.zip
+          cd ..
+
+      - name: Zip up box-3-emu files in the build output directory
+        run: |
+          cd ecad
+          # zip all files which match box-3-emu.* or box-3-emu-gerbers*.zip
+          zip -j -r box-3-emu.zip build/box-3-emu.* build/box-3-emu-gerbers*.zip
+          cd ..
 
       - name: Upload Box-3-Emu
         uses: actions/upload-artifact@v4

--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -53,14 +53,14 @@ jobs:
         run: |
           cd ecad
           # zip all files which match box-emu.* or box-emu-gerbers*.zip
-          zip -r box-emu.zip build/box-emu.* build/box-emu-gerbers*.zip kibot-box-emu/*
+          zip -j box-emu.zip build/box-emu.* build/box-emu-gerbers*.zip kibot-box-emu/*.png kibot-box-emu/*.pdf kibot-box-emu/*.step
           cd ..
 
       - name: Zip up box-3-emu files in the build output directory
         run: |
           cd ecad
           # zip all files which match box-3-emu.* or box-3-emu-gerbers*.zip
-          zip -r box-3-emu.zip build/box-3-emu.* build/box-3-emu-gerbers*.zip kibot-box-3-emu/*
+          zip -j box-3-emu.zip build/box-3-emu.* build/box-3-emu-gerbers*.zip kibot-box-3-emu/*.png kibot-box-3-emu/*.pdf kibot-box-3-emu/*.step
           cd ..
 
       - name: Upload Box-3-Emu

--- a/.github/workflows/atopile.yml
+++ b/.github/workflows/atopile.yml
@@ -35,7 +35,7 @@ jobs:
           # Required - kibot config file
           config: ecad/config.kibot.yaml
           # optional - prefix to output defined in config
-          dir: 'ecad/build'
+          dir: 'ecad/kibot-box-emu'
           # optional - PCB design file
           board: 'ecad/elec/layout/box-emu/box-emu.kicad_pcb'
 
@@ -45,7 +45,7 @@ jobs:
           # Required - kibot config file
           config: ecad/config.kibot.yaml
           # optional - prefix to output defined in config
-          dir: 'ecad/build'
+          dir: 'ecad/kibot-box-3-emu'
           # optional - PCB design file
           board: 'ecad/elec/layout/box-3-emu/box-3-emu.kicad_pcb'
 
@@ -53,14 +53,14 @@ jobs:
         run: |
           cd ecad
           # zip all files which match box-emu.* or box-emu-gerbers*.zip
-          zip -j -r box-emu.zip build/box-emu.* build/box-emu-gerbers*.zip
+          zip -j -r box-emu.zip build/box-emu.* build/box-emu-gerbers*.zip kibot-box-emu/*
           cd ..
 
       - name: Zip up box-3-emu files in the build output directory
         run: |
           cd ecad
           # zip all files which match box-3-emu.* or box-3-emu-gerbers*.zip
-          zip -j -r box-3-emu.zip build/box-3-emu.* build/box-3-emu-gerbers*.zip
+          zip -j -r box-3-emu.zip build/box-3-emu.* build/box-3-emu-gerbers*.zip kibot-box-3-emu/*
           cd ..
 
       - name: Upload Box-3-Emu
@@ -70,6 +70,7 @@ jobs:
           path: |
             ecad/build/box-3-emu.*
             ecad/build/box-3-emu-gerbers*.zip
+            ecad/kibot-box-3-emu/*
 
       - name: Upload Box-Emu
         uses: actions/upload-artifact@v4
@@ -78,6 +79,7 @@ jobs:
           path: |
             ecad/build/box-emu.*
             ecad/build/box-emu-gerbers*.zip
+            ecad/kibot-box-emu/*
 
       - name: Attach files to release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,22 @@
 name: Build
 
-on: [pull_request]
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'components/*'
+      - 'main/*'
+      - 'sdkconfig.defaults'
+      - 'partitions.csv'
+      - '.github/workflows/build.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'components/*'
+      - 'main/*'
+      - 'sdkconfig.defaults'
+      - 'partitions.csv'
+      - '.github/workflows/build.yml'
 
 jobs:
   build:

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -26,10 +26,10 @@ jobs:
         path: '.'
         command: './patches.sh && idf.py build'
 
-      - name: Zip up firmware binaries
-        run: |
-          # zip the firmware bin files and flash args
-          zip -j -r firmware-binaries.zip build/esp-box-emu.bin build/bootloader/bootloader.bin build/partition_table/partition-table.bin build/flash_args
+    - name: Zip up firmware binaries
+      run: |
+        # zip the firmware bin files and flash args
+        zip -j -r firmware-binaries.zip build/esp-box-emu.bin build/bootloader/bootloader.bin build/partition_table/partition-table.bin build/flash_args
 
     - name: Upload Build Outputs
       uses: actions/upload-artifact@v4

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -6,6 +6,12 @@ on:
   pull_request_target:
     branches:
       - "*"
+    paths:
+      - 'components/*'
+      - 'main/*'
+      - 'sdkconfig.defaults'
+      - 'partitions.csv'
+      - '.github/workflows/static_analysis.yml'
 
 jobs:
   static_analysis:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 

--- a/ecad/config.kibot.yaml
+++ b/ecad/config.kibot.yaml
@@ -49,7 +49,6 @@ outputs:
       rotate_x: 3
       rotate_z: 3
       ray_tracing: true
-      kicad_3d_url:
 
   # Blender render
   - name: 3D_top_view_HQ

--- a/ecad/config.kibot.yaml
+++ b/ecad/config.kibot.yaml
@@ -7,6 +7,7 @@ global:
   silk_screen_color: 'white'
 
 outputs:
+  # Export PDF of the board layers (right now just top / bottom)
   - name: print_pdf
     comment: "PDF for the PCB"
     type: pcb_print
@@ -33,10 +34,12 @@ outputs:
           sheet: 'Bottom layer'
           mirror: true
 
+  # Export STEP file of pcb
   - name: 3D
     comment: "STEP 3D model"
     type: step
 
+  # KiCAD render
   - name: 3D_top_view
     comment: "3D render from top"
     type: render_3d
@@ -46,7 +49,9 @@ outputs:
       rotate_x: 3
       rotate_z: 3
       ray_tracing: true
+      kicad_3d_url:
 
+  # Blender render
   - name: 3D_top_view_HQ
     comment: "3D render from top (High Quality)"
     type: blender_export
@@ -60,3 +65,61 @@ outputs:
       outputs:
         - type: blender
         - type: render
+
+  # Diff:
+  # Recursive git submodules aren't supported (submodules inside submodules)
+  - name: PCB Diff
+    comment: 'Generates a PDF with the differences between two PCBs'
+    type: 'diff'
+    dir: 'Example/diff_dir'
+    options:
+      # [number=5] [0,100] Color tolerance (fuzzyness) for the `stats` mode
+      fuzz: 5
+      # [string='current'] [git,file,output,multivar,current] How to interpret the `new` name. Use `git` for a git hash, branch, etc.
+      # Use `current` for the currently loaded PCB/Schematic.
+      # Use `file` for a file name. Use `output` to specify the name of a `pcb_variant`/`sch_variant` output.
+      # Use `multivar` to compare a set of variants, in this mode `new` is the list of outputs for the variants.
+      # This is an extension of the `output` mode.
+      # If `old` is also `multivar` then it becomes the reference, otherwise we compare using pairs of variants
+      new_type: 'current'
+      # [string='HEAD'] Reference file. When using git use `HEAD` to refer to the last commit.
+      # Use `HEAD~` to refer the previous to the last commit.
+      # As `HEAD` is for the whole repo you can use `KIBOT_LAST-n` to make
+      # reference to the changes in the PCB/SCH. The `n` value is how many
+      # changes in the history you want to go back. A 0 is the same as `HEAD`,
+      # a 1 means the last time the PCB/SCH was changed, etc.
+      # Use `KIBOT_TAG-n` to search for the last tag skipping `n` tags.
+      # Important: when using the `checkout` GitHub action you just get the
+      # last commit. To clone the full repo use `fetch-depth: '0'`
+      old: 'HEAD'
+      # [string='git'] [git,file,output,multivar] How to interpret the `old` name. Use `git` for a git hash, branch, etc.
+      # Use `file` for a file name. Use `output` to specify the name of a `pcb_variant`/`sch_variant` output.
+      # Use `multivar` to specify a reference file when `new_type` is also `multivar`
+      old_type: 'git'
+      # [boolean=false] Only include the pages with differences in the output PDF.
+      # Note that when no differences are found we get a page saying *No diff*
+      only_different: false
+      # [boolean=false] Compare only the main schematic page (root page)
+      only_first_sch_page: false
+      # [string='%f-%i%I%v.%x'] Filename for the output (%i=diff_pcb/diff_sch, %x=pdf). Affected by global options
+      output: '%f-%i%I%v.%x'
+      # [boolean=true] Compare the PCB, otherwise compare the schematic
+      pcb: true
+      # [string|list(string)='_none'] Name of the filter to transform fields before applying other filters.
+      # A short-cut to use for simple cases where a variant is an overkill
+      pre_transform: '_none'
+      # [number=0] [0,1000000] Error threshold for the `stats` mode, 0 is no error. When specified a
+      # difference bigger than the indicated value will make the diff fail.
+      # KiBot will return error level 29 and the diff generation will be aborted
+      threshold: 0
+      # [boolean=false] When creating the link name of an output file related to a variant use the variant
+      # `file_id` instead of its name
+      use_file_id: false
+      # [string=''] Board variant to apply
+      variant: ''
+      # [string='global'] [global,fill,unfill,none] How to handle PCB zones. The default is *global* and means that we
+      # fill zones if the *check_zone_fills* preflight is enabled. The *fill* option always forces
+      # a refill, *unfill* forces a zone removal and *none* lets the zones unchanged.
+      # Be careful with the cache when changing this setting
+      zones: 'global'
+    layers: all

--- a/ecad/config.kibot.yaml
+++ b/ecad/config.kibot.yaml
@@ -24,10 +24,6 @@ outputs:
             - layer: F.SilkS
             - layer: Dwgs.User
           sheet: 'Top layer'
-        - layers: [ GND.Cu, Dwgs.User ]
-          sheet: 'GND plane'
-        - layers: [ Power.Cu, Dwgs.User ]
-          sheet: 'Power plane'
         - layers:
             - layer: B.Cu
             - layer: B.Mask

--- a/ecad/config.kibot.yaml
+++ b/ecad/config.kibot.yaml
@@ -1,0 +1,66 @@
+# Example KiBot config file
+kibot:
+  version: 1
+
+global:
+  solder_mask_color: 'black'
+  silk_screen_color: 'white'
+
+outputs:
+  - name: print_pdf
+    comment: "PDF for the PCB"
+    type: pcb_print
+    options:
+      force_edge_cuts: true
+      keep_temporal_files: true
+      scaling: 2.0
+      pages:
+        - layers: [ F.Paste, F.Adhes, Dwgs.User, F.Fab ]
+          sheet: 'Fabrication layers'
+        - layers:
+            - layer: F.Cu
+            - layer: F.Mask
+              color: '#14332440'
+            - layer: F.SilkS
+            - layer: Dwgs.User
+          sheet: 'Top layer'
+        - layers: [ GND.Cu, Dwgs.User ]
+          sheet: 'GND plane'
+        - layers: [ Power.Cu, Dwgs.User ]
+          sheet: 'Power plane'
+        - layers:
+            - layer: B.Cu
+            - layer: B.Mask
+              color: '#14332440'
+            - layer: B.SilkS
+            - layer: Dwgs.User
+          sheet: 'Bottom layer'
+          mirror: true
+
+  - name: 3D
+    comment: "STEP 3D model"
+    type: step
+
+  - name: 3D_top_view
+    comment: "3D render from top"
+    type: render_3d
+    # see https://kibot.readthedocs.io/en/master/configuration/outputs/render_3d.html
+    options:
+      zoom: 4
+      rotate_x: 3
+      rotate_z: 3
+      ray_tracing: true
+
+  - name: 3D_top_view_HQ
+    comment: "3D render from top (High Quality)"
+    type: blender_export
+    options:
+      render_options:
+        transparent_background: true
+        samples: 20
+      point_of_view:
+        rotate_x: 30
+        rotate_z: -20
+      outputs:
+        - type: blender
+        - type: render

--- a/ecad/config.kibot.yaml
+++ b/ecad/config.kibot.yaml
@@ -65,60 +65,60 @@ outputs:
         - type: blender
         - type: render
 
-  # Diff:
-  # Recursive git submodules aren't supported (submodules inside submodules)
-  - name: PCB Diff
-    comment: 'Generates a PDF with the differences between two PCBs'
-    type: 'diff'
-    dir: 'Example/diff_dir'
-    options:
-      # [number=5] [0,100] Color tolerance (fuzzyness) for the `stats` mode
-      fuzz: 5
-      # [string='current'] [git,file,output,multivar,current] How to interpret the `new` name. Use `git` for a git hash, branch, etc.
-      # Use `current` for the currently loaded PCB/Schematic.
-      # Use `file` for a file name. Use `output` to specify the name of a `pcb_variant`/`sch_variant` output.
-      # Use `multivar` to compare a set of variants, in this mode `new` is the list of outputs for the variants.
-      # This is an extension of the `output` mode.
-      # If `old` is also `multivar` then it becomes the reference, otherwise we compare using pairs of variants
-      new_type: 'current'
-      # [string='HEAD'] Reference file. When using git use `HEAD` to refer to the last commit.
-      # Use `HEAD~` to refer the previous to the last commit.
-      # As `HEAD` is for the whole repo you can use `KIBOT_LAST-n` to make
-      # reference to the changes in the PCB/SCH. The `n` value is how many
-      # changes in the history you want to go back. A 0 is the same as `HEAD`,
-      # a 1 means the last time the PCB/SCH was changed, etc.
-      # Use `KIBOT_TAG-n` to search for the last tag skipping `n` tags.
-      # Important: when using the `checkout` GitHub action you just get the
-      # last commit. To clone the full repo use `fetch-depth: '0'`
-      old: 'HEAD'
-      # [string='git'] [git,file,output,multivar] How to interpret the `old` name. Use `git` for a git hash, branch, etc.
-      # Use `file` for a file name. Use `output` to specify the name of a `pcb_variant`/`sch_variant` output.
-      # Use `multivar` to specify a reference file when `new_type` is also `multivar`
-      old_type: 'git'
-      # [boolean=false] Only include the pages with differences in the output PDF.
-      # Note that when no differences are found we get a page saying *No diff*
-      only_different: false
-      # [boolean=false] Compare only the main schematic page (root page)
-      only_first_sch_page: false
-      # [string='%f-%i%I%v.%x'] Filename for the output (%i=diff_pcb/diff_sch, %x=pdf). Affected by global options
-      output: '%f-%i%I%v.%x'
-      # [boolean=true] Compare the PCB, otherwise compare the schematic
-      pcb: true
-      # [string|list(string)='_none'] Name of the filter to transform fields before applying other filters.
-      # A short-cut to use for simple cases where a variant is an overkill
-      pre_transform: '_none'
-      # [number=0] [0,1000000] Error threshold for the `stats` mode, 0 is no error. When specified a
-      # difference bigger than the indicated value will make the diff fail.
-      # KiBot will return error level 29 and the diff generation will be aborted
-      threshold: 0
-      # [boolean=false] When creating the link name of an output file related to a variant use the variant
-      # `file_id` instead of its name
-      use_file_id: false
-      # [string=''] Board variant to apply
-      variant: ''
-      # [string='global'] [global,fill,unfill,none] How to handle PCB zones. The default is *global* and means that we
-      # fill zones if the *check_zone_fills* preflight is enabled. The *fill* option always forces
-      # a refill, *unfill* forces a zone removal and *none* lets the zones unchanged.
-      # Be careful with the cache when changing this setting
-      zones: 'global'
-    layers: all
+  # # Diff:
+  # # Recursive git submodules aren't supported (submodules inside submodules)
+  # - name: PCB Diff
+  #   comment: 'Generates a PDF with the differences between two PCBs'
+  #   type: 'diff'
+  #   dir: 'Example/diff_dir'
+  #   options:
+  #     # [number=5] [0,100] Color tolerance (fuzzyness) for the `stats` mode
+  #     fuzz: 5
+  #     # [string='current'] [git,file,output,multivar,current] How to interpret the `new` name. Use `git` for a git hash, branch, etc.
+  #     # Use `current` for the currently loaded PCB/Schematic.
+  #     # Use `file` for a file name. Use `output` to specify the name of a `pcb_variant`/`sch_variant` output.
+  #     # Use `multivar` to compare a set of variants, in this mode `new` is the list of outputs for the variants.
+  #     # This is an extension of the `output` mode.
+  #     # If `old` is also `multivar` then it becomes the reference, otherwise we compare using pairs of variants
+  #     new_type: 'current'
+  #     # [string='HEAD'] Reference file. When using git use `HEAD` to refer to the last commit.
+  #     # Use `HEAD~` to refer the previous to the last commit.
+  #     # As `HEAD` is for the whole repo you can use `KIBOT_LAST-n` to make
+  #     # reference to the changes in the PCB/SCH. The `n` value is how many
+  #     # changes in the history you want to go back. A 0 is the same as `HEAD`,
+  #     # a 1 means the last time the PCB/SCH was changed, etc.
+  #     # Use `KIBOT_TAG-n` to search for the last tag skipping `n` tags.
+  #     # Important: when using the `checkout` GitHub action you just get the
+  #     # last commit. To clone the full repo use `fetch-depth: '0'`
+  #     old: 'HEAD'
+  #     # [string='git'] [git,file,output,multivar] How to interpret the `old` name. Use `git` for a git hash, branch, etc.
+  #     # Use `file` for a file name. Use `output` to specify the name of a `pcb_variant`/`sch_variant` output.
+  #     # Use `multivar` to specify a reference file when `new_type` is also `multivar`
+  #     old_type: 'git'
+  #     # [boolean=false] Only include the pages with differences in the output PDF.
+  #     # Note that when no differences are found we get a page saying *No diff*
+  #     only_different: false
+  #     # [boolean=false] Compare only the main schematic page (root page)
+  #     only_first_sch_page: false
+  #     # [string='%f-%i%I%v.%x'] Filename for the output (%i=diff_pcb/diff_sch, %x=pdf). Affected by global options
+  #     output: '%f-%i%I%v.%x'
+  #     # [boolean=true] Compare the PCB, otherwise compare the schematic
+  #     pcb: true
+  #     # [string|list(string)='_none'] Name of the filter to transform fields before applying other filters.
+  #     # A short-cut to use for simple cases where a variant is an overkill
+  #     pre_transform: '_none'
+  #     # [number=0] [0,1000000] Error threshold for the `stats` mode, 0 is no error. When specified a
+  #     # difference bigger than the indicated value will make the diff fail.
+  #     # KiBot will return error level 29 and the diff generation will be aborted
+  #     threshold: 0
+  #     # [boolean=false] When creating the link name of an output file related to a variant use the variant
+  #     # `file_id` instead of its name
+  #     use_file_id: false
+  #     # [string=''] Board variant to apply
+  #     variant: ''
+  #     # [string='global'] [global,fill,unfill,none] How to handle PCB zones. The default is *global* and means that we
+  #     # fill zones if the *check_zone_fills* preflight is enabled. The *fill* option always forces
+  #     # a refill, *unfill* forces a zone removal and *none* lets the zones unchanged.
+  #     # Be careful with the cache when changing this setting
+  #     zones: 'global'
+  #   layers: all


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update CI actions to only run when paths in the PR match specific patterns to ensure ecad-only PRs don't trigger build / static analysis, and code changes don't trigger ecad builds
* Generate and upload 3d renders of the boards

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Shortens the amount of work / wait time for PR checks
* Getting one step closer to automated image generation for board updates :)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This PR

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
