### PR TITLE
feat: update espp to 0.13.1 for interrupt-driven touch

### DIFF
--- a/components/box-emu/src/box-emu.cpp
+++ b/components/box-emu/src/box-emu.cpp
@@ -267,7 +267,6 @@ bool BoxEmu::initialize_gamepad() {
   input_timer_ = std::make_shared<espp::HighResolutionTimer>(espp::HighResolutionTimer::Config{
       .name = "Input timer",
       .callback = [this]() {
-        espp::EspBox::get().update_touch();
         update_gamepad_state();
       }});
   uint64_t period_us = 30 * 1000;

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -44,6 +44,8 @@ CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
 # FATFS config
 # Support long file names using buffer in heap
 CONFIG_FATFS_LFN_HEAP=y
+CONFIG_FATFS_VFS_FSTAT_BLKSIZE=16384 # increase speed of buffered reads
+CONFIG_FATFS_USE_FASTSEEK=y # increase speed of seeking for read-mode files
 
 #
 # USB config


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update espp to v0.13.1 for interrupt driven touch
* Minor update to VFS config in sdkconfig for faster buffered reading

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reduces the amount of work we're doing by not polling the touch driver - instead only communicating when there is new data.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running on box 3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.