### PR TITLE
box-emu: Update to explicitly define io address and improve loggingg

### DIFF
--- a/components/box-emu/include/box-emu.hpp
+++ b/components/box-emu/include/box-emu.hpp
@@ -202,6 +202,7 @@ protected:
   struct version0 {
     using InputDriver = espp::Mcp23x17;
     typedef Input<version0, InputDriver> InputType;
+    static constexpr auto input_address = InputDriver::DEFAULT_ADDRESS;
     static constexpr uint16_t START_PIN =  (1<<0) << 0; // start pin is on port a of the MCP23x17
     static constexpr uint16_t SELECT_PIN = (1<<1) << 0; // select pin is on port a of the MCP23x17
     static constexpr uint16_t UP_PIN =    (1<<0) << 8; // up pin is on port b of the MCP23x17
@@ -227,6 +228,7 @@ protected:
   struct version1 {
     using InputDriver = espp::Aw9523;
     typedef Input<version1, InputDriver> InputType;
+    static constexpr auto input_address = InputDriver::DEFAULT_ADDRESS;
     static constexpr gpio_num_t VBAT_SENSE_PIN = GPIO_NUM_14; // battery sense pin is on GPIO 14
     static constexpr gpio_num_t AW9523_INT_PIN = GPIO_NUM_21; // interrupt pin is on GPIO 21
     static constexpr uint16_t UP_PIN =    (1<<0) << 0; // up pin is on port 0 of the AW9523

--- a/components/box-emu/src/box-emu.cpp
+++ b/components/box-emu/src/box-emu.cpp
@@ -9,16 +9,18 @@ BoxEmu::Version BoxEmu::version() const {
 }
 
 void BoxEmu::detect() {
-  bool mcp23x17_found = external_i2c_.probe_device(espp::Mcp23x17::DEFAULT_ADDRESS);
-  bool aw9523_found = external_i2c_.probe_device(espp::Aw9523::DEFAULT_ADDRESS);
-  if (aw9523_found) {
+  bool version0_found = external_i2c_.probe_device(version0::input_address);
+  bool version1_found = external_i2c_.probe_device(version1::input_address);
+  if (version1_found) {
     // Version 1
     version_ = BoxEmu::Version::V1;
-  } else if (mcp23x17_found) {
+  } else if (version0_found) {
     // Version 0
     version_ = BoxEmu::Version::V0;
   } else {
     logger_.warn("No box-emu hardware detected");
+    logger_.warn("\tProbed for MCP23x17 (version0) at 0x{:02x}", version0::input_address);
+    logger_.warn("\tProbed for AW9523 (version1) at 0x{:02x}", version1::input_address);
     // No box detected
     version_ = BoxEmu::Version::UNKNOWN;
     return;
@@ -230,6 +232,7 @@ bool BoxEmu::initialize_gamepad() {
   if (version_ == BoxEmu::Version::V0) {
     auto raw_input = new version0::InputType(
                                              std::make_shared<version0::InputDriver>(version0::InputDriver::Config{
+                                                 .device_address = version0::input_address,
                                                  .port_0_direction_mask = version0::PORT_0_DIRECTION_MASK,
                                                  .port_0_interrupt_mask = version0::PORT_0_INTERRUPT_MASK,
                                                  .port_1_direction_mask = version0::PORT_1_DIRECTION_MASK,
@@ -243,6 +246,7 @@ bool BoxEmu::initialize_gamepad() {
   } else if (version_ == BoxEmu::Version::V1) {
     auto raw_input = new version1::InputType(
                                              std::make_shared<version1::InputDriver>(version1::InputDriver::Config{
+                                                 .device_address = version1::input_address,
                                                  .port_0_direction_mask = version1::PORT_0_DIRECTION_MASK,
                                                  .port_0_interrupt_mask = version1::PORT_0_INTERRUPT_MASK,
                                                  .port_1_direction_mask = version1::PORT_1_DIRECTION_MASK,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add io address for version 0 and version 1
* Update logging when hardware cannot be found

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Helps with debugging hardware and more useful in the future when more variants may exist.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running on box and box-3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.