### PR TITLE
feat: Update to remove display task (espp update) and fix sa for carts

### DIFF
--- a/components/box-emu/example/main/box_emu_example.cpp
+++ b/components/box-emu/example/main/box_emu_example.cpp
@@ -154,8 +154,8 @@ static size_t load_audio() {
   }
 
   // these are configured in the CMakeLists.txt file
-  extern const char wav_start[] asm("_binary_click_wav_start");
-  extern const char wav_end[] asm("_binary_click_wav_end");
+  extern const char wav_start[] asm("_binary_click_wav_start"); // cppcheck-suppress syntaxError
+  extern const char wav_end[] asm("_binary_click_wav_end");    // cppcheck-suppress syntaxError
 
   // -1 due to the size being 1 byte too large, I think because end is the byte
   // immediately after the last byte in the memory but I'm not sure - cmm 2022-08-20

--- a/components/box-emu/src/box-emu.cpp
+++ b/components/box-emu/src/box-emu.cpp
@@ -50,15 +50,8 @@ bool BoxEmu::initialize_box() {
     return false;
   }
   static constexpr size_t pixel_buffer_size = espp::EspBox::lcd_width() * num_rows_in_framebuffer;
-  static constexpr int update_period_ms = 16;
-  espp::Task::BaseConfig display_task_config = {
-    .name = "Display",
-    .stack_size_bytes = 6 * 1024,
-    .priority = 10,
-    .core_id = 1,
-  };
   // initialize the LVGL display for the esp-box
-  if (!box.initialize_display(pixel_buffer_size, display_task_config, update_period_ms)) {
+  if (!box.initialize_display(pixel_buffer_size)) {
     logger_.error("Failed to initialize display!");
     return false;
   }

--- a/components/gbc/src/gameboy.cpp
+++ b/components/gbc/src/gameboy.cpp
@@ -36,6 +36,7 @@ struct fb fb;
 struct pcm pcm;
 static uint8_t currentBuffer = 0;
 
+// cppcheck-suppress constParameterPointer
 extern "C" void die(char *fmt, ...) {
   // do nothing...
 }

--- a/components/nes/src/video_audio.cpp
+++ b/components/nes/src/video_audio.cpp
@@ -238,6 +238,7 @@ extern "C" void osd_getinput(void)
 	}
 }
 
+// cppcheck-suppress constParameterPointer
 extern "C" void osd_getmouse(int *x, int *y, int *button)
 {
 }

--- a/components/sms/src/sms.cpp
+++ b/components/sms/src/sms.cpp
@@ -37,6 +37,7 @@ void sms_frame(int skip_render);
 void sms_init(void);
 void sms_reset(void);
 
+// cppcheck-suppress constParameterPointer
 extern "C" void system_manage_sram(uint8 *sram, int slot, int mode) {
 }
 

--- a/main/cart.hpp
+++ b/main/cart.hpp
@@ -171,13 +171,11 @@ public:
       // now resume the menu
       menu_->resume();
       display_->force_refresh();
-      display_->resume();
       // wait here until the menu is no longer shown
       while (!menu_->is_paused()) {
         using namespace std::chrono_literals;
         std::this_thread::sleep_for(100ms);
       }
-      display_->pause();
       // make sure to clear the screen before we resume the game
       espp::St7789::clear(0,0,320,240);
       // only run the post_menu if we are still running

--- a/main/gbc_cart.hpp
+++ b/main/gbc_cart.hpp
@@ -14,7 +14,7 @@ public:
     init();
   }
 
-  ~GbcCart() {
+  virtual ~GbcCart() override {
     deinit();
   }
 

--- a/main/genesis_cart.hpp
+++ b/main/genesis_cart.hpp
@@ -14,7 +14,7 @@ public:
     init();
   }
 
-  ~GenesisCart() {
+  virtual ~GenesisCart() override {
     logger_.info("~GenesisCart()");
     deinit();
   }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -104,8 +104,6 @@ extern "C" void app_main(void) {
       // Cart handles platform specific code, state management, etc.
       {
         std::unique_ptr<Cart> cart(make_cart(selected_rom, display));
-
-        display->pause();
         if (cart) {
           while (cart->run());
         } else {
@@ -128,6 +126,5 @@ extern "C" void app_main(void) {
 
     gui.resume();
     display->force_refresh();
-    display->resume();
   }
 }

--- a/main/msx_cart.hpp
+++ b/main/msx_cart.hpp
@@ -14,7 +14,7 @@ public:
     init();
   }
 
-  ~MsxCart() {
+  virtual ~MsxCart() override {
     logger_.info("~MsxCart()");
     deinit();
   }

--- a/main/nes_cart.hpp
+++ b/main/nes_cart.hpp
@@ -14,7 +14,7 @@ public:
     init();
   }
 
-  ~NesCart() {
+  virtual ~NesCart() override {
     deinit();
   }
 

--- a/main/sms_cart.hpp
+++ b/main/sms_cart.hpp
@@ -14,7 +14,7 @@ public:
     init();
   }
 
-  ~SmsCart() {
+  virtual ~SmsCart() override {
     logger_.info("~SmsCart()");
     deinit();
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update to latest espp with display udpates
* Update carts to properly mark destructors as virtual overrides
* Remove calls to display::pause and display::resume because they're no longer needed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Keeps the code up to date and cleans it up some.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running on ESP-BOX.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.