### PR TITLE
feat(box-emu): Refactor to reduce deps on EspBox, instead depending on box-emu

### DIFF
--- a/components/box-emu/include/box-emu.hpp
+++ b/components/box-emu/include/box-emu.hpp
@@ -39,6 +39,38 @@
 
 class BoxEmu : public espp::BaseComponent {
 public:
+
+  // Define the BSP class for easier access, and potential ability to change the
+  // BSP if we want to support other targets.
+  using Bsp = espp::EspBox;
+
+  // Wrap some of the EspBox defines / methods for easier access and to remove
+  // dependency on EspBox from other components
+  using button_callback_t = Bsp::button_callback_t;
+  using Pixel = Bsp::Pixel;
+  using DisplayDriver = Bsp::DisplayDriver;
+  using TouchpadData = Bsp::TouchpadData;
+  using touch_callback_t = Bsp::touch_callback_t;
+
+  // Wrap some of the EspBox defines / methods for easier access and to remove
+  // dependency on EspBox from other components
+  static constexpr size_t lcd_width() { return Bsp::lcd_width(); }
+  static constexpr size_t lcd_height() { return Bsp::lcd_height(); }
+  Bsp::Pixel *vram0() const { return Bsp::get().vram0(); }
+  Bsp::Pixel *vram1() const { return Bsp::get().vram1(); }
+  uint8_t *frame_buffer0() const { return Bsp::get().frame_buffer0(); }
+  uint8_t *frame_buffer1() const { return Bsp::get().frame_buffer1(); }
+  void brightness(float v){ Bsp::get().brightness(v); }
+  float brightness() const { return Bsp::get().brightness(); }
+  bool is_muted() const { return Bsp::get().is_muted(); }
+  void mute(bool v) { Bsp::get().mute(v); }
+  void volume(float volume) { Bsp::get().volume(volume); }
+  float volume() const { return Bsp::get().volume(); }
+  void audio_sample_rate(int rate) { Bsp::get().audio_sample_rate(rate); }
+  uint32_t audio_sample_rate() const { return Bsp::get().audio_sample_rate(); }
+  void play_audio(const uint8_t *data, size_t size) { Bsp::get().play_audio(data, size); }
+  void play_audio(const std::vector<uint8_t> &data) { Bsp::get().play_audio(data); }
+
   /// The Version of the BoxEmu
   enum class Version {
     UNKNOWN, ///< unknown box
@@ -194,7 +226,7 @@ protected:
       int volume_change = (volume_up * 10) + (volume_down * -10);
       if (volume_change != 0) {
         // change the volume
-        auto &box = espp::EspBox::get();
+        auto &box = Bsp::get();
         float current_volume = box.volume();
         float new_volume = std::clamp<float>(current_volume + volume_change, 0, 100);
         box.volume(new_volume);
@@ -316,12 +348,12 @@ protected:
   std::unique_ptr<espp::Task> video_task_{nullptr};
   QueueHandle_t video_queue_{nullptr};
 
-  size_t display_width_{espp::EspBox::lcd_width()};
-  size_t display_height_{espp::EspBox::lcd_height()};
+  size_t display_width_{Bsp::lcd_width()};
+  size_t display_height_{Bsp::lcd_height()};
 
-  size_t native_width_{espp::EspBox::lcd_width()};
-  size_t native_height_{espp::EspBox::lcd_height()};
-  int native_pitch_{espp::EspBox::lcd_width()};
+  size_t native_width_{Bsp::lcd_width()};
+  size_t native_height_{Bsp::lcd_height()};
+  int native_pitch_{Bsp::lcd_width()};
 
   const uint16_t* palette_{nullptr};
   size_t palette_size_{256};

--- a/components/gbc/src/gameboy.cpp
+++ b/components/gbc/src/gameboy.cpp
@@ -73,7 +73,7 @@ void run_to_vblank() {
   if (pcm.pos > 100) {
     auto audio_sample_count = pcm.pos;
     auto audio_buffer = (uint8_t*)pcm.buf;
-    espp::EspBox::get().play_audio(audio_buffer, audio_sample_count * sizeof(int16_t));
+    BoxEmu::get().play_audio(audio_buffer, audio_sample_count * sizeof(int16_t));
     pcm.pos = 0;
   }
 
@@ -120,8 +120,8 @@ void init_gameboy(const std::string& rom_filename, uint8_t *romdata, size_t rom_
   BoxEmu::get().native_size(GAMEBOY_SCREEN_WIDTH, GAMEBOY_SCREEN_HEIGHT);
   BoxEmu::get().palette(nullptr);
 
-  displayBuffer[0] = (uint16_t*)espp::EspBox::get().frame_buffer0();
-  displayBuffer[1] = (uint16_t*)espp::EspBox::get().frame_buffer1();
+  displayBuffer[0] = (uint16_t*)BoxEmu::get().frame_buffer0();
+  displayBuffer[1] = (uint16_t*)BoxEmu::get().frame_buffer1();
 
   memset(&fb, 0, sizeof(fb));
   fb.w = GAMEBOY_SCREEN_WIDTH;
@@ -134,7 +134,7 @@ void init_gameboy(const std::string& rom_filename, uint8_t *romdata, size_t rom_
   fb.dirty = 0;
   framebuffer = displayBuffer[0];
 
-  espp::EspBox::get().audio_sample_rate(GAMEBOY_AUDIO_SAMPLE_RATE);
+  BoxEmu::get().audio_sample_rate(GAMEBOY_AUDIO_SAMPLE_RATE);
   // save the audio buffer
   auto buf = pcm.buf;
   auto len = pcm.len;
@@ -207,7 +207,7 @@ void save_gameboy(std::string_view save_path) {
 }
 
 std::vector<uint8_t> get_gameboy_video_buffer() {
-  const uint8_t* frame_buffer = espp::EspBox::get().frame_buffer0();
+  const uint8_t* frame_buffer = BoxEmu::get().frame_buffer0();
   // copy the frame buffer to a new buffer
   auto width = GAMEBOY_SCREEN_WIDTH;
   auto height = GAMEBOY_SCREEN_HEIGHT;
@@ -221,5 +221,5 @@ std::vector<uint8_t> get_gameboy_video_buffer() {
 void deinit_gameboy() {
   // now unload everything
   loader_unload();
-  espp::EspBox::get().audio_sample_rate(48000);
+  BoxEmu::get().audio_sample_rate(48000);
 }

--- a/components/genesis/src/genesis.cpp
+++ b/components/genesis/src/genesis.cpp
@@ -165,11 +165,11 @@ static void init(uint8_t *romdata, size_t rom_data_size) {
   frame_counter = 0;
   muteFrameCount = 0;
 
-  espp::EspBox::get().audio_sample_rate(REG1_PAL ? GWENESIS_AUDIO_FREQ_PAL/2 : GWENESIS_AUDIO_FREQ_NTSC/2);
+  BoxEmu::get().audio_sample_rate(REG1_PAL ? GWENESIS_AUDIO_FREQ_PAL/2 : GWENESIS_AUDIO_FREQ_NTSC/2);
 
   frame_buffer = frame_buffer_index
-    ? espp::EspBox::get().frame_buffer1()
-    : espp::EspBox::get().frame_buffer0();
+    ? BoxEmu::get().frame_buffer1()
+    : BoxEmu::get().frame_buffer0();
   gwenesis_vdp_set_buffer(frame_buffer);
 
   initialized = true;
@@ -187,7 +187,7 @@ void IRAM_ATTR run_genesis_rom() {
   static GamepadState previous_state = {};
   auto state = BoxEmu::get().gamepad_state();
 
-  bool sound_enabled = !espp::EspBox::get().is_muted();
+  bool sound_enabled = !BoxEmu::get().is_muted();
 
   frameskip = sound_enabled ? full_frameskip : muted_frameskip;
 
@@ -317,8 +317,8 @@ void IRAM_ATTR run_genesis_rom() {
     // ping pong the frame buffer
     frame_buffer_index = !frame_buffer_index;
     frame_buffer = frame_buffer_index
-      ? espp::EspBox::get().frame_buffer1()
-      : espp::EspBox::get().frame_buffer0();
+      ? BoxEmu::get().frame_buffer1()
+      : BoxEmu::get().frame_buffer0();
     gwenesis_vdp_set_buffer(frame_buffer);
   }
 
@@ -338,7 +338,7 @@ void IRAM_ATTR run_genesis_rom() {
       }
       gwenesis_sn76489_buffer[i] = sample;
     }
-    espp::EspBox::get().play_audio((uint8_t*)gwenesis_ym2612_buffer, audio_len * sizeof(int16_t));
+    BoxEmu::get().play_audio((uint8_t*)gwenesis_ym2612_buffer, audio_len * sizeof(int16_t));
   }
 
   // manage statistics
@@ -385,5 +385,5 @@ std::vector<uint8_t> get_genesis_video_buffer() {
 }
 
 void deinit_genesis() {
-  espp::EspBox::get().audio_sample_rate(48000);
+  BoxEmu::get().audio_sample_rate(48000);
 }

--- a/components/gui/include/gui.hpp
+++ b/components/gui/include/gui.hpp
@@ -71,7 +71,7 @@ public:
   void set_mute(bool muted);
 
   void toggle_mute() {
-    set_mute(!espp::EspBox::get().is_muted());
+    set_mute(!BoxEmu::get().is_muted());
   }
 
   void set_audio_level(int new_audio_level);
@@ -140,7 +140,7 @@ protected:
   void toggle_usb();
 
   void update_shared_state() {
-    auto &box = espp::EspBox::get();
+    auto &box = BoxEmu::get();
     set_mute(box.is_muted());
     set_audio_level(box.volume());
     set_brightness(box.brightness());
@@ -152,7 +152,7 @@ protected:
   void on_rom_focused(int index);
 
   void on_mute_button_pressed(const std::vector<uint8_t>& data) {
-    set_mute(espp::EspBox::get().is_muted());
+    set_mute(BoxEmu::get().is_muted());
   }
 
   void on_battery(const std::vector<uint8_t>& data);

--- a/components/gui/src/gui.cpp
+++ b/components/gui/src/gui.cpp
@@ -7,7 +7,7 @@ extern "C" {
 }
 
 void Gui::set_mute(bool muted) {
-  espp::EspBox::get().mute(muted);
+  BoxEmu::get().mute(muted);
   if (muted) {
     lv_obj_add_state(ui_mutebutton, LV_STATE_CHECKED);
   } else {
@@ -18,13 +18,13 @@ void Gui::set_mute(bool muted) {
 void Gui::set_audio_level(int new_audio_level) {
   new_audio_level = std::clamp(new_audio_level, 0, 100);
   lv_bar_set_value(ui_volumebar, new_audio_level, LV_ANIM_ON);
-  espp::EspBox::get().volume(new_audio_level);
+  BoxEmu::get().volume(new_audio_level);
 }
 
 void Gui::set_brightness(int new_brightness) {
   new_brightness = std::clamp(new_brightness, 10, 100);
   lv_bar_set_value(ui_brightnessbar, new_brightness, LV_ANIM_ON);
-  espp::EspBox::get().brightness((float)new_brightness);
+  BoxEmu::get().brightness((float)new_brightness);
 }
 
 void Gui::set_video_setting(VideoSetting setting) {
@@ -147,7 +147,7 @@ void Gui::init_ui() {
   // set the animation speed for the roller
   lv_obj_set_style_anim_time(ui_roms, 30, LV_PART_MAIN);
 
-  lv_bar_set_value(ui_volumebar, espp::EspBox::get().volume(), LV_ANIM_OFF);
+  lv_bar_set_value(ui_volumebar, BoxEmu::get().volume(), LV_ANIM_OFF);
 
   // rom screen navigation
   lv_obj_add_event_cb(ui_settingsbutton, &Gui::event_callback, LV_EVENT_PRESSED, static_cast<void*>(this));
@@ -283,12 +283,12 @@ void Gui::on_pressed(lv_event_t *e) {
   // volume controls
   bool is_volume_up_button = (target == ui_volumeupbutton);
   if (is_volume_up_button) {
-    set_audio_level(espp::EspBox::get().volume() + 10);
+    set_audio_level(BoxEmu::get().volume() + 10);
     return;
   }
   bool is_volume_down_button = (target == ui_volumedownbutton);
   if (is_volume_down_button) {
-    set_audio_level(espp::EspBox::get().volume() - 10);
+    set_audio_level(BoxEmu::get().volume() - 10);
     return;
   }
   bool is_mute_button = (target == ui_mutebutton);
@@ -299,13 +299,13 @@ void Gui::on_pressed(lv_event_t *e) {
   // brightness controlsn
   bool is_brightness_up_button = (target == ui_brightnessupbutton);
   if (is_brightness_up_button) {
-    int brightness = espp::EspBox::get().brightness();
+    int brightness = BoxEmu::get().brightness();
     set_brightness(brightness + 10);
     return;
   }
   bool is_brightness_down_button = (target == ui_brightnessdownbutton);
   if (is_brightness_down_button) {
-    int brightness = espp::EspBox::get().brightness();
+    int brightness = BoxEmu::get().brightness();
     set_brightness(brightness - 10);
     return;
   }
@@ -346,7 +346,7 @@ void Gui::on_pressed(lv_event_t *e) {
 
 void Gui::on_volume(const std::vector<uint8_t>& data) {
   // the volume was changed, update our display of the volume
-  lv_bar_set_value(ui_volumebar, espp::EspBox::get().volume(), LV_ANIM_ON);
+  lv_bar_set_value(ui_volumebar, BoxEmu::get().volume(), LV_ANIM_ON);
 }
 
 void Gui::on_battery(const std::vector<uint8_t>& data) {

--- a/components/menu/include/menu.hpp
+++ b/components/menu/include/menu.hpp
@@ -87,7 +87,7 @@ public:
   void set_mute(bool muted);
 
   void toggle_mute() {
-    set_mute(!espp::EspBox::get().is_muted());
+    set_mute(!BoxEmu::get().is_muted());
   }
 
   void set_audio_level(int new_audio_level);
@@ -124,7 +124,7 @@ protected:
   void update_fps_label(float fps);
 
   void update_shared_state() {
-    auto &box = espp::EspBox::get();
+    auto &box = BoxEmu::get();
     set_mute(box.is_muted());
     set_audio_level(box.volume());
     set_brightness(box.brightness());
@@ -134,7 +134,7 @@ protected:
   VideoSetting get_video_setting();
 
   void on_mute_button_pressed(const std::vector<uint8_t>& data) {
-    set_mute(espp::EspBox::get().is_muted());
+    set_mute(BoxEmu::get().is_muted());
   }
 
   void update() {

--- a/components/menu/src/menu.cpp
+++ b/components/menu/src/menu.cpp
@@ -211,7 +211,7 @@ void Menu::update_fps_label(float fps) {
 }
 
 void Menu::set_mute(bool muted) {
-  espp::EspBox::get().mute(muted);
+  BoxEmu::get().mute(muted);
   if (muted) {
     lv_obj_add_state(ui_volume_mute_btn, LV_STATE_CHECKED);
   } else {
@@ -222,13 +222,13 @@ void Menu::set_mute(bool muted) {
 void Menu::set_audio_level(int new_audio_level) {
   new_audio_level = std::clamp(new_audio_level, 0, 100);
   lv_bar_set_value(ui_Bar2, new_audio_level, LV_ANIM_ON);
-  espp::EspBox::get().volume(new_audio_level);
+  BoxEmu::get().volume(new_audio_level);
 }
 
 void Menu::set_brightness(int new_brightness) {
   new_brightness = std::clamp(new_brightness, 10, 100);
   lv_bar_set_value(ui_brightness_bar, new_brightness, LV_ANIM_ON);
-  espp::EspBox::get().brightness((float)new_brightness);
+  BoxEmu::get().brightness((float)new_brightness);
 }
 
 void Menu::set_video_setting(VideoSetting setting) {
@@ -300,12 +300,12 @@ void Menu::on_pressed(lv_event_t *e) {
   // volume controls
   bool is_volume_up_button = (target == ui_volume_inc_btn);
   if (is_volume_up_button) {
-    set_audio_level(espp::EspBox::get().volume() + 10);
+    set_audio_level(BoxEmu::get().volume() + 10);
     return;
   }
   bool is_volume_down_button = (target == ui_volume_dec_btn);
   if (is_volume_down_button) {
-    set_audio_level(espp::EspBox::get().volume() - 10);
+    set_audio_level(BoxEmu::get().volume() - 10);
     return;
   }
   bool is_mute_button = (target == ui_volume_mute_btn);
@@ -316,19 +316,19 @@ void Menu::on_pressed(lv_event_t *e) {
   // brightness controls
   bool is_brightness_up_button = (target == ui_brightness_inc_btn);
   if (is_brightness_up_button) {
-    set_brightness(espp::EspBox::get().brightness() + 10);
+    set_brightness(BoxEmu::get().brightness() + 10);
     return;
   }
   bool is_brightness_down_button = (target == ui_brightness_dec_btn);
   if (is_brightness_down_button) {
-    set_brightness(espp::EspBox::get().brightness() - 10);
+    set_brightness(BoxEmu::get().brightness() - 10);
     return;
   }
 }
 
 void Menu::on_volume(const std::vector<uint8_t>& data) {
   // the volume was changed, update our display of the volume
-  lv_bar_set_value(ui_Bar2, espp::EspBox::get().volume(), LV_ANIM_ON);
+  lv_bar_set_value(ui_Bar2, BoxEmu::get().volume(), LV_ANIM_ON);
 }
 
 void Menu::on_battery(const std::vector<uint8_t>& data) {

--- a/components/nes/src/nes.cpp
+++ b/components/nes/src/nes.cpp
@@ -42,7 +42,7 @@ void init_nes(const std::string& rom_filename, uint8_t *romdata, size_t rom_data
   BoxEmu::get().native_size(NES_SCREEN_WIDTH, NES_VISIBLE_HEIGHT);
   BoxEmu::get().palette(get_nes_palette());
 
-  espp::EspBox::get().audio_sample_rate(44100 / 2);
+  BoxEmu::get().audio_sample_rate(44100 / 2);
 
   nes_insertcart(rom_filename.c_str(), console_nes);
   vid_setmode(NES_SCREEN_WIDTH, NES_VISIBLE_HEIGHT);
@@ -94,7 +94,7 @@ std::vector<uint8_t> get_nes_video_buffer() {
   std::vector<uint8_t> frame(NES_SCREEN_WIDTH * NES_VISIBLE_HEIGHT * 2);
   // the frame data for the NES is stored in frame_buffer0 as a 8 bit index into the palette
   // we need to convert this to a 16 bit RGB565 value
-  const uint8_t *frame_buffer0 = espp::EspBox::get().frame_buffer0();
+  const uint8_t *frame_buffer0 = BoxEmu::get().frame_buffer0();
   const uint16_t *palette = get_nes_palette();
   for (int i = 0; i < NES_SCREEN_WIDTH * NES_VISIBLE_HEIGHT; i++) {
     uint8_t index = frame_buffer0[i];
@@ -107,5 +107,5 @@ std::vector<uint8_t> get_nes_video_buffer() {
 
 void deinit_nes() {
   nes_poweroff();
-  espp::EspBox::get().audio_sample_rate(48000);
+  BoxEmu::get().audio_sample_rate(48000);
 }

--- a/components/nes/src/video_audio.cpp
+++ b/components/nes/src/video_audio.cpp
@@ -41,11 +41,11 @@ static void (*audio_callback)(void *buffer, int length) = NULL;
 extern "C" void do_audio_frame() {
     if (audio_callback == NULL) return;
     static int num_channels = 2;
-    static int num_samples = espp::EspBox::get().audio_sample_rate() * num_channels / NES_REFRESH_RATE;
+    static int num_samples = BoxEmu::get().audio_sample_rate() * num_channels / NES_REFRESH_RATE;
     static int num_bytes = num_samples * sizeof(int16_t);
     static int16_t *audio_frame = (int16_t*)heap_caps_malloc(num_bytes, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
     audio_callback(audio_frame, num_samples);
-    espp::EspBox::get().play_audio((uint8_t*)audio_frame, num_bytes);
+    BoxEmu::get().play_audio((uint8_t*)audio_frame, num_bytes);
 }
 
 extern "C" void osd_setsound(void (*playfunc)(void *buffer, int length))
@@ -67,7 +67,7 @@ static int osd_init_sound(void) {
 
 extern "C" void osd_getsoundinfo(sndinfo_t *info)
 {
-   info->sample_rate = espp::EspBox::get().audio_sample_rate();
+   info->sample_rate = BoxEmu::get().audio_sample_rate();
    info->bps = 16;
 }
 
@@ -159,7 +159,7 @@ static void clear(uint8 color)
 static bitmap_t *lock_write(void)
 {
 //   SDL_LockSurface(mySurface);
-   myBitmap = bmp_createhw((uint8*)espp::EspBox::get().frame_buffer1(), DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH*2);
+   myBitmap = bmp_createhw((uint8*)BoxEmu::get().frame_buffer1(), DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_WIDTH*2);
    // make sure they don't try to delete the frame buffer lol
    myBitmap->hardware = true;
    return myBitmap;
@@ -172,7 +172,7 @@ static void free_write(int num_dirties, rect_t *dirty_rects)
 }
 
 static void custom_blit(const bitmap_t *bmp, int num_dirties, rect_t *dirty_rects) {
-    uint8_t *lcdfb = espp::EspBox::get().frame_buffer0();
+    uint8_t *lcdfb = BoxEmu::get().frame_buffer0();
     if (bmp->line[0] != NULL)
     {
         memcpy(lcdfb, bmp->line[0], 256 * 224);

--- a/components/sms/src/sms.cpp
+++ b/components/sms/src/sms.cpp
@@ -59,7 +59,7 @@ static void init(uint8_t *romdata, size_t rom_data_size) {
   bitmap.width = SMS_SCREEN_WIDTH;
   bitmap.height = SMS_VISIBLE_HEIGHT;
   bitmap.pitch = bitmap.width;
-  bitmap.data = espp::EspBox::get().frame_buffer0();
+  bitmap.data = BoxEmu::get().frame_buffer0();
 
   cart.sram = sms_sram;
   sms.wram = sms_ram;
@@ -68,7 +68,7 @@ static void init(uint8_t *romdata, size_t rom_data_size) {
 
   set_option_defaults();
 
-  option.sndrate = espp::EspBox::get().audio_sample_rate();
+  option.sndrate = BoxEmu::get().audio_sample_rate();
   option.overscan = 0;
   option.extra_gg = 0;
 
@@ -153,8 +153,8 @@ void run_sms_rom() {
     // ping pong the frame buffer
     frame_buffer_index = !frame_buffer_index;
     bitmap.data = frame_buffer_index
-      ? (uint8_t*)espp::EspBox::get().frame_buffer1()
-      : (uint8_t*)espp::EspBox::get().frame_buffer0();
+      ? (uint8_t*)BoxEmu::get().frame_buffer1()
+      : (uint8_t*)BoxEmu::get().frame_buffer0();
   } else {
     system_frame(1);
   }
@@ -179,7 +179,7 @@ void run_sms_rom() {
   auto sms_audio_buffer_len = sms_snd.sample_count - 1;
 
   // push the audio buffer to the audio task
-  espp::EspBox::get().play_audio((uint8_t*)sms_audio_buffer, sms_audio_buffer_len * 2 * 2); // 2 channels, 2 bytes per sample
+  BoxEmu::get().play_audio((uint8_t*)sms_audio_buffer, sms_audio_buffer_len * 2 * 2); // 2 channels, 2 bytes per sample
 
   // update unlock based on x button
   static bool last_x = false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update `box-emu` component to include wrappers / accessors for some underlying audio and video functions from the EspBox
* Update all other affected components to replace access of `EspBox::` with `BoxEmu::` wrappers, so that it would be easier / simpler to target other systems

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
WIP to support #95

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ensure the project still builds

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.