### PR TITLE
feat: Remove EspBox references from main code for easier portability

### DIFF
--- a/main/cart.hpp
+++ b/main/cart.hpp
@@ -155,7 +155,7 @@ public:
   virtual bool run() {
     running_ = true;
     // handle touchpad so we can know if the user presses the menu
-    auto touch = espp::EspBox::get().touchpad_data();
+    auto touch = BoxEmu::Bsp::get().touchpad_data();
     bool btn_state = touch.btn_state;
     // also get the gamepad input state so we can know if the user presses the
     // start/select buttons together to bring up the menu

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -24,8 +24,6 @@ extern "C" void app_main(void) {
   logger.info("Bootup");
 
   // initialize the hardware abstraction layer
-  espp::EspBox &box = espp::EspBox::get();
-  logger.info("Running on {}", box.box_type());
   BoxEmu &emu = BoxEmu::get();
   logger.info("Box Emu version: {}", emu.version());
 
@@ -67,7 +65,7 @@ extern "C" void app_main(void) {
 
   logger.info("initializing gui...");
 
-  auto display = box.display();
+  auto display = BoxEmu::Bsp::get().display();
 
   // initialize the gui
   Gui gui({


### PR DESCRIPTION
Related to #96 - just missed a couple refs in the `main` code 😅 